### PR TITLE
Allow command-line/environment configuration

### DIFF
--- a/rq_dashboard/app.py
+++ b/rq_dashboard/app.py
@@ -1,10 +1,11 @@
 from flask import Flask
 from rq_dashboard import RQDashboard
+import os
 
 
 app = Flask(__name__)
 
-# Override config
-app.config['DEBUG'] = True
+if os.getenv('RQ_DASHBOARD_SETTINGS'):
+    app.config.from_envvar('RQ_DASHBOARD_SETTINGS')
 
 RQDashboard(app, '')

--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -18,7 +18,8 @@ dashboard = Blueprint('rq_dashboard', __name__,
 
 @dashboard.before_app_first_request
 def setup_rq_connection():
-    redis_conn = Redis()
+    redis_conn = Redis(host=current_app.config.get('REDIS_HOST', 'localhost'),
+                       port=current_app.config.get('REDIS_PORT', 6379))
     push_connection(redis_conn)
 
 

--- a/rq_dashboard/scripts/rq_dashboard.py
+++ b/rq_dashboard/scripts/rq_dashboard.py
@@ -1,12 +1,31 @@
 #!/usr/bin/env python
-import sys
+import optparse
 from ..app import app
 
 
 def main():
-    host = '127.0.0.1'
-    port = 9181
-    app.run(host=host, port=port)
+    parser = optparse.OptionParser("usage: %prog [options]")
+    parser.add_option('-l', '--listen', dest='host',
+                      metavar='IP', help='IP to listen on')
+    parser.add_option('-p', '--port', dest='port', type='int',
+                      metavar='PORT', help='port to listen on')
+    parser.add_option('-s', '--redis-server', dest='redis_host',
+                      metavar='IP', help='IP of redis server')
+    parser.add_option('--redis-port', dest='redis_port', type='int',
+                      metavar='PORT', help='port of redis server')
+    (options, args) = parser.parse_args()
+
+    # populate app.config from options, defaulting to app.config's original
+    # values, if specified, finally defaulting to something sensible.
+    app.config['HOST'] = options.host or app.config.get('HOST', '0.0.0.0')
+    app.config['PORT'] = options.port or app.config.get('PORT', 9181)
+
+    # override app.config from options if specified.  Otherwise leave untouched,
+    # so the client can use its own defauls if app.config has no values.
+    if options.redis_host: app.config['REDIS_HOST'] = options.redis_host
+    if options.redis_port: app.config['REDIS_PORT'] = options.redis_port
+
+    app.run(host=app.config['HOST'], port=app.config['PORT'])
 
 if __name__ == '__main__':
-    main(sys.argv)
+    main()


### PR DESCRIPTION
The flask app now looks for a configuration file in the
RQ_DASHBOARD_SETTINGS environment variable and loads it if it is there.

In addition, the rq_dashboard script allows the host and IP of both the
app and the redis server to be specified on the commandline, overriding
the configuration file if necessary, and providing sensible defaults.

Fixes issue #17
