### PR TITLE
Added support to use a redis connection url as parameter on rq-dashboard 

### DIFF
--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -1,4 +1,5 @@
 from redis import Redis
+from redis import from_url
 from rq import push_connection
 from functools import wraps
 import times
@@ -18,7 +19,10 @@ dashboard = Blueprint('rq_dashboard', __name__,
 
 @dashboard.before_app_first_request
 def setup_rq_connection():
-    redis_conn = Redis(host=current_app.config.get('REDIS_HOST', 'localhost'),
+    if current_app.config.get('REDIS_URL'):
+        redis_conn = from_url(current_app.config.get('REDIS_URL'))
+    else:
+        redis_conn = Redis(host=current_app.config.get('REDIS_HOST', 'localhost'),
                        port=current_app.config.get('REDIS_PORT', 6379),
                        password=current_app.config.get('REDIS_PASSWORD', None),
                        db=current_app.config.get('REDIS_DB', 0))

--- a/rq_dashboard/scripts/rq_dashboard.py
+++ b/rq_dashboard/scripts/rq_dashboard.py
@@ -25,6 +25,9 @@ def main():
     parser.add_option('-D', '--redis-database', dest='redis_database', type='int',
                       metavar='DB',
                       help='database of Redis server')
+    parser.add_option('-u', '--redis_url', dest='redis_url_connection', 
+                      metavar='REDIS_URL', 
+                      help='redis url connection')
     (options, args) = parser.parse_args()
 
     # Populate app.config from options, defaulting to app.config's original
@@ -42,6 +45,8 @@ def main():
         app.config['REDIS_PASSWORD'] = options.redis_password
     if options.redis_database:
         app.config['REDIS_DB'] = options.redis_database
+    
+    app.config['REDIS_URL'] = options.redis_url_connection or None
 
     if len(args) > 0:
         parser.print_help()


### PR DESCRIPTION
Now is possible to pass an optional argument to rq-dashboard to setup the redis connection

  -u REDIS_URL, --redis_url=REDIS_URL
                        redis url connection
