### PR TITLE
Add home button to dashboard

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/dashboard.html
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.html
@@ -138,9 +138,16 @@
         </div>
     </div>
 </div>
+<div class="row">
+    <div class="span12">
+        <div class="section">
+            <p class="intro"><a href="/" id="home-btn" class="btn btn-small" style="float: left"><i class="icon-arrow-left"></i> Home</a></p>
+        </div>
+    </div>
+</div>
+
 
 {% endblock %}
-
 
 
 {% block inline_js %}


### PR DESCRIPTION
url_for('rq_dashboard.overview') builds the link to the dashboard from within the main app.

Once you're in the dashboard though, there's no way back. This just adds a button to go to '/'. If there's a better way to do this, I'm all ears.
