### PR TITLE
Allow users to set the Redis URL for RQDashboard via environmental variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ use a different URL root, use the following:
 RQDashboard(app, url_prefix='/some/other/url')
 ```
 
+## Setting the Redis URL
+
+RQ dashboard defaults to the following settings:
+
+```python
+REDIS_HOST = 'localhost'
+REDIS_PORT = 6379
+REDIS_PASSWORD = None
+REDIS_DB = 0
+```
+
+To change this, you can set these values or the value of `REDIS_URL` in your Flask app's `app.config`.
+
+Alternatively, you can set an environmental variable `RQ_DASHBOARD_REDIS_URL` to the full Redis URL, including authentication and port.  Please note that this will override anything that you set it your `app.config`, so if you decide to stop using this method, make sure you remove that environmental variable.
 
 ## Maturity notes
 

--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -9,6 +9,7 @@ from flask import render_template
 from rq import Queue, Worker
 from rq import cancel_job, requeue_job
 from rq import get_failed_queue
+import os
 
 
 dashboard = Blueprint('rq_dashboard', __name__,
@@ -19,7 +20,11 @@ dashboard = Blueprint('rq_dashboard', __name__,
 
 @dashboard.before_app_first_request
 def setup_rq_connection():
-    if current_app.config.get('REDIS_URL'):
+    # 'RQ_DASHBOARD_REDIS_URL' environmental variable takes priority;
+    #   otherwise, we look at the Flask app's config for the redis information.
+    if os.environ.get('RQ_DASHBOARD_REDIS_URL', None):
+        redis_conn = from_url(os.environ.get('RQ_DASHBOARD_REDIS_URL'))
+    elif current_app.config.get('REDIS_URL'):
         redis_conn = from_url(current_app.config.get('REDIS_URL'))
     else:
         redis_conn = Redis(host=current_app.config.get('REDIS_HOST', 'localhost'),


### PR DESCRIPTION
This is a tiny update to allow users of rq_dashboard to set the information for the redis connection from the environment. 

This came up when I was trying to integrate RQDashboard into my Flask app, with your suggested syntax:

``` python
# app.py
RQDashboard(app)
```

The problem was, no matter what I did or how I played with `app.config`, I could never get RQDashboard to recognize my URL.  This was a big problem because I'm running it in Heroku, where not only is my information most likely going to be in environmental variables, but the variable is called `'REDISTOGO_URL'`, not `'REDIS_URL'`, though obviously I can copy the value over if needed.

With this change, a user could get around this issue and specify the URL for RQDashboard without affecting the queue or any other part of the app in any other way, simply by setting an environmental var `RQ_DASHBOARD_REDIS_URL` to the full redis URL.
