### PR TITLE
Add ability to specify polling interval

### DIFF
--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -152,3 +152,8 @@ def list_workers():
     workers = [dict(name=worker.name, queues=serialize_queue_names(worker),
         state=worker.state) for worker in Worker.all()]
     return dict(workers=workers)
+
+@dashboard.context_processor
+def inject_interval():
+    interval = current_app.config.get('RQ_POLL_INTERVAL', 2500)
+    return dict(poll_interval=interval)

--- a/rq_dashboard/scripts/rq_dashboard.py
+++ b/rq_dashboard/scripts/rq_dashboard.py
@@ -25,9 +25,12 @@ def main():
     parser.add_option('-D', '--redis-database', dest='redis_database', type='int',
                       metavar='DB',
                       help='database of Redis server')
-    parser.add_option('-u', '--redis_url', dest='redis_url_connection', 
-                      metavar='REDIS_URL', 
+    parser.add_option('-u', '--redis_url', dest='redis_url_connection',
+                      metavar='REDIS_URL',
                       help='redis url connection')
+    parser.add_option('--interval', dest='poll_interval', type='int',
+                      metavar='POLL_INTERVAL',
+                      help='refresh interval')
     (options, args) = parser.parse_args()
 
     # Populate app.config from options, defaulting to app.config's original
@@ -45,7 +48,9 @@ def main():
         app.config['REDIS_PASSWORD'] = options.redis_password
     if options.redis_database:
         app.config['REDIS_DB'] = options.redis_database
-    
+    if options.poll_interval:
+        app.config['RQ_POLL_INTERVAL'] = options.poll_interval
+
     app.config['REDIS_URL'] = options.redis_url_connection or None
 
     if len(args) > 0:

--- a/rq_dashboard/templates/rq_dashboard/dashboard.html
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.html
@@ -151,5 +151,6 @@
 
 
 {% block inline_js %}
+var POLL_INTERVAL = {{ poll_interval }};
 {% include "rq_dashboard/dashboard.js" %}
 {% endblock %}

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -1,4 +1,3 @@
-var POLL_INTERVAL = 2500;
 
 var url_for = function(name, param) {
     var url = '';


### PR DESCRIPTION
Set with --interval for the standalone app or
RQ_POLL_INTERVAL in configuration specified with
RQ_DASHBOARD_SETTINGS.

Fixes #26
