### PR TITLE
Fix for broken init_app

### DIFF
--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -13,7 +13,4 @@ class RQDashboard(object):
 
     def init_app(self, app):
         """Initializes the RQ-Dashboard for the specified application."""
-        if self.app is not None:
-            raise Exception('RQ-dashboard is already associated with an application.')
-
         app.register_blueprint(dashboard, url_prefix=self.url_prefix)


### PR DESCRIPTION
The update to init_app causes an Exception to be thrown every time if you instantiate RQDashboard with the app parameter not set to None
