### PR TITLE
HTML escaping for description and exc_info

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/dashboard.html
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.html
@@ -109,14 +109,14 @@
             <tr data-role="job" data-job-id="<%= id %>">
                 <td>
                     <i class="icon-file" style="opacity: .5;"></i>
-                    <span class="description"><%= description %></span>
+                    <span class="description"><%= $('<div/>').text(description).html() %></span>
                     <% if (exc_info) { %>
                         <span class="origin">from <strong><%= origin %></strong></span>
                     <% } %>
                     <div class="job_id"><%= id %></div>
                     <% if (exc_info) { %>
                         <span class="end_date">Failed <%= ended_at %></span>
-                        <pre class="exc_info"><%= exc_info %></pre>
+                        <pre class="exc_info"><%= $('<div/>').text(exc_info).html() %></pre>
                     <% } %>
                 </td>
                 <td><span class="creation_date"><%= created_at %></span></td>


### PR DESCRIPTION
Currently there is a bug in rq_dashboard if we are printing text with HTML.

For example, having a description of <h1>Hello</h1> will be rendered with the h1 tag.

To stop this, jQuery escaping has been added.
