### PR TITLE
Fixes json routes when using rq-dashboard from a url_prefix other than /

### DIFF
--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -1,6 +1,6 @@
 from redis import Redis
 from redis import from_url
-from rq import push_connection
+from rq import push_connection, pop_connection
 from functools import wraps
 import times
 from flask import Blueprint
@@ -41,13 +41,11 @@ def setup_rq_connection():
 
 @dashboard.before_request
 def push_rq_connection():
-    print "pushing connection", connections['redis_conn']
     push_connection(connections['redis_conn'])
 
 @dashboard.teardown_request
 def pop_rq_connection(exception=None):
     popped = pop_connection()
-    print "popping connection", popped
 
 def jsonify(f):
     @wraps(f)

--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -26,7 +26,7 @@ def authentication_hook():
     if current_app.auth_handler and not current_app.auth_handler():
         abort(401)
 
-@dashboard.before_app_first_request
+@dashboard.before_request
 def setup_rq_connection():
     if current_app.config.get('REDIS_URL'):
         redis_conn = from_url(current_app.config.get('REDIS_URL'))

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -1,15 +1,15 @@
 
 var url_for = function(name, param) {
     var url = '';
-    if (name == 'queues') { url = '/queues.json'; }
-    else if (name == 'workers') { url = '/workers.json'; }
-    else if (name == 'cancel_job') { url = '/job/' + encodeURIComponent(param) + '/cancel'; }
-    else if (name == 'requeue_job') { url = '/job/' + encodeURIComponent(param) + '/requeue'; }
+    if (name == 'queues') { url = 'queues.json'; }
+    else if (name == 'workers') { url = 'workers.json'; }
+    else if (name == 'cancel_job') { url = 'job/' + encodeURIComponent(param) + '/cancel'; }
+    else if (name == 'requeue_job') { url = 'job/' + encodeURIComponent(param) + '/requeue'; }
     return url;
 };
 
 var url_for_jobs = function(param, page) {
-    var url = '/jobs/' + encodeURIComponent(param) + '/' + page + '.json';
+    var url = 'jobs/' + encodeURIComponent(param) + '/' + page + '.json';
     return url;
 };
 


### PR DESCRIPTION
I noticed that all of the JSON endpoints were failing when trying to run rq-dashboard integrated within my own app. The problem was just in dashboard.js. Tested standalone and it still works fine.
