### PR TITLE
Create redis connection at start on app launch

### DIFF
--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -11,6 +11,7 @@ class RQDashboard(object):
         else:
             self.app = None
         self.auth_handler = auth_handler
+        self.redis_conn = None
 
     def init_app(self, app):
         """Initializes the RQ-Dashboard for the specified application."""

--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -1,6 +1,6 @@
 from redis import Redis
 from redis import from_url
-from rq import push_connection
+from rq import push_connection, pop_connection
 from functools import wraps
 import times
 from flask import Blueprint
@@ -17,6 +17,9 @@ dashboard = Blueprint('rq_dashboard', __name__,
         static_folder='static',
         )
 
+connections = {
+    'redis_conn': None
+}
 
 @dashboard.before_request
 def authentication_hook():
@@ -29,14 +32,21 @@ def authentication_hook():
 @dashboard.before_app_first_request
 def setup_rq_connection():
     if current_app.config.get('REDIS_URL'):
-        redis_conn = from_url(current_app.config.get('REDIS_URL'))
+        connections['redis_conn'] = from_url(current_app.config.get('REDIS_URL'))
     else:
-        redis_conn = Redis(host=current_app.config.get('REDIS_HOST', 'localhost'),
+        connections['redis_conn'] = Redis(host=current_app.config.get('REDIS_HOST', 'localhost'),
                        port=current_app.config.get('REDIS_PORT', 6379),
                        password=current_app.config.get('REDIS_PASSWORD', None),
                        db=current_app.config.get('REDIS_DB', 0))
-    push_connection(redis_conn)
 
+
+@dashboard.before_request
+def push_rq_connection():
+    push_connection(connections['redis_conn'])
+
+@dashboard.teardown_request
+def pop_rq_connection(exception=None):
+    pop_connection()
 
 def jsonify(f):
     @wraps(f)


### PR DESCRIPTION
Push and pop redis connection with each request to work with multiple processes under uwsgi

This solves the no redis connection problem when running multiple processes under uwsgi, by creating an app level redis connection, then pushing/popping that connection as needed. It also performs the same when not running under uwsgi.
