### PR TITLE
Extension cleanup

### DIFF
--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -15,4 +15,3 @@ class RQDashboard(object):
     def init_app(self, app):
         """Initializes the RQ-Dashboard for the specified application."""
         app.register_blueprint(dashboard, url_prefix=self.url_prefix)
-        app.config['rq_url_prefix'] = self.url_prefix

--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -10,8 +10,9 @@ class RQDashboard(object):
             self.init_app(app)
         else:
             self.app = None
-        self.app.auth_handler = auth_handler
+        self.auth_handler = auth_handler
 
     def init_app(self, app):
         """Initializes the RQ-Dashboard for the specified application."""
         app.register_blueprint(dashboard, url_prefix=self.url_prefix)
+        app.extensions['rq-dashboard'] = self

--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -106,11 +106,13 @@ def overview(queue_name, page):
     else:
         queue = Queue(queue_name)
 
+    extension = current_app.extensions['rq-dashboard']
     return render_template('rq_dashboard/dashboard.html',
             workers=Worker.all(),
             queue=queue,
             page=page,
-            queues=Queue.all())
+            queues=Queue.all(),
+            rq_url_prefix=extension.url_prefix)
 
 
 @dashboard.route('/job/<job_id>/cancel', methods=['POST'])

--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -23,7 +23,8 @@ def authentication_hook():
     """ Allow the parent app to authenticate user's access to the dashboard
         with it's own auth_handler method that must return True or False
     """
-    if current_app.auth_handler and not current_app.auth_handler():
+    auth_handler = current_app.extensions['rq-dashboard'].auth_handler
+    if auth_handler and not auth_handler():
         abort(401)
 
 @dashboard.before_app_first_request

--- a/rq_dashboard/templates/rq_dashboard/dashboard.html
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.html
@@ -177,5 +177,5 @@
 
 {% block inline_js %}
 var POLL_INTERVAL = {{ poll_interval }};
-{% include "rq_dashboard/dashboard.js" %}
+{% include "rq_dashboard/dashboard.js" with context %}
 {% endblock %}

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -1,7 +1,5 @@
-{% set rq_url_prefix = url_for('.overview')[:-1]|tojson|safe %}
-
 var url_for = function(name, param) {
-    var url = {{ rq_url_prefix }};
+    var url = {{ rq_url_prefix|tojson|safe }};
     if (name == 'queues') { url += '/queues.json'; }
     else if (name == 'workers') { url += '/workers.json'; }
     else if (name == 'cancel_job') { url += '/job/' + encodeURIComponent(param) + '/cancel'; }
@@ -10,7 +8,7 @@ var url_for = function(name, param) {
 };
 
 var url_for_jobs = function(param, page) {
-    var url = {{ rq_url_prefix }} + '/jobs/' + encodeURIComponent(param) + '/' + page + '.json';
+    var url = {{ rq_url_prefix|tojson|safe }} + '/jobs/' + encodeURIComponent(param) + '/' + page + '.json';
     return url;
 };
 

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -1,15 +1,16 @@
+{% set rq_url_prefix = url_for('.overview')[:-1]|tojson|safe %}
 
 var url_for = function(name, param) {
-    var url = '{{ config.rq_url_prefix }}';
-    if (name == 'queues') { url = '{{ config.rq_url_prefix }}/queues.json'; }
-    else if (name == 'workers') { url = '{{ config.rq_url_prefix }}/workers.json'; }
-    else if (name == 'cancel_job') { url = '{{ config.rq_url_prefix }}/job/' + encodeURIComponent(param) + '/cancel'; }
-    else if (name == 'requeue_job') { url = '{{ config.rq_url_prefix }}/job/' + encodeURIComponent(param) + '/requeue'; }
+    var url = {{ rq_url_prefix }};
+    if (name == 'queues') { url += '/queues.json'; }
+    else if (name == 'workers') { url += '/workers.json'; }
+    else if (name == 'cancel_job') { url += '/job/' + encodeURIComponent(param) + '/cancel'; }
+    else if (name == 'requeue_job') { url += '/job/' + encodeURIComponent(param) + '/requeue'; }
     return url;
 };
 
 var url_for_jobs = function(param, page) {
-    var url = '{{ config.rq_url_prefix }}/jobs/' + encodeURIComponent(param) + '/' + page + '.json';
+    var url = {{ rq_url_prefix }} + '/jobs/' + encodeURIComponent(param) + '/' + page + '.json';
     return url;
 };
 


### PR DESCRIPTION
Clean up how rq-dashboard behaves as an extension:
- Don't pollute the app's configuration.
- Don't add an attribute on the app object, we can use the [extension dictionary](http://flask.pocoo.org/docs/api/#flask.Flask.extensions).
