### PR TITLE
Encapsulate redis_conn in the extension object and add a factory option

### DIFF
--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -3,7 +3,7 @@ from .dashboard import dashboard
 
 
 class RQDashboard(object):
-    def __init__(self, app=None, url_prefix='/rq', auth_handler=None):
+    def __init__(self, app=None, url_prefix='/rq', auth_handler=None, redis_conn=None, redis_conn_factory=None):
         self.url_prefix = url_prefix
         if app is not None:
             self.app = app
@@ -11,7 +11,8 @@ class RQDashboard(object):
         else:
             self.app = None
         self.auth_handler = auth_handler
-        self.redis_conn = None
+        self.redis_conn_factory = redis_conn_factory
+        self.redis_conn = redis_conn
 
     def init_app(self, app):
         """Initializes the RQ-Dashboard for the specified application."""


### PR DESCRIPTION
Hi,

Great project! I've made two small changes to how connections are created, hopefully for the better :)

Now `redis_conn` is really an attribute of the extension and not the app, so (although highly unlikely) someone can have more than one dashboard, but more importantly, it doesn't pollute the app dict.

Also, `RQDashboard` accepts a connection or a connection factory so the user can use his/her own method to create redis connections.

Thanks,
Tal
