### PR TITLE
fix display of workers

### DIFF
--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -210,7 +210,7 @@ def list_workers():
         return [q.name for q in worker.queues]
 
     workers = [dict(name=worker.name, queues=serialize_queue_names(worker),
-        state=worker.state) for worker in Worker.all()]
+        state=worker.get_state()) for worker in Worker.all()]
     return dict(workers=workers)
 
 @dashboard.context_processor


### PR DESCRIPTION
Accessing worker.state now raises a DeprecationWarning, which in turn causes worker.json generation to fail.  Use the new worker.get_state() instead.
