### PR TITLE
Added python-dateutil to requirements.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ redis
 -e git+git@github.com:nvie/rq.git#egg=rq
 simplejson
 times
+python-dateutil>=2.1


### PR DESCRIPTION
Upon running for the first time rq-dashboard complained about missing python-dateutil.
