### PR TITLE
Use url_for('.overview') instead of extension.url_prefix for rq_url_prefix

### DIFF
--- a/rq_dashboard/dashboard.py
+++ b/rq_dashboard/dashboard.py
@@ -116,13 +116,12 @@ def overview(queue_name, page):
     else:
         queue = Queue(queue_name)
 
-    extension = current_app.extensions['rq-dashboard']
     return render_template('rq_dashboard/dashboard.html',
             workers=Worker.all(),
             queue=queue,
             page=page,
             queues=Queue.all(),
-            rq_url_prefix=extension.url_prefix)
+            rq_url_prefix=url_for('.overview'))
 
 
 @dashboard.route('/job/<job_id>/cancel', methods=['POST'])

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -1,14 +1,14 @@
 var url_for = function(name, param) {
     var url = {{ rq_url_prefix|tojson|safe }};
-    if (name == 'queues') { url += '/queues.json'; }
-    else if (name == 'workers') { url += '/workers.json'; }
-    else if (name == 'cancel_job') { url += '/job/' + encodeURIComponent(param) + '/cancel'; }
-    else if (name == 'requeue_job') { url += '/job/' + encodeURIComponent(param) + '/requeue'; }
+    if (name == 'queues') { url += 'queues.json'; }
+    else if (name == 'workers') { url += 'workers.json'; }
+    else if (name == 'cancel_job') { url += 'job/' + encodeURIComponent(param) + '/cancel'; }
+    else if (name == 'requeue_job') { url += 'job/' + encodeURIComponent(param) + '/requeue'; }
     return url;
 };
 
 var url_for_jobs = function(param, page) {
-    var url = {{ rq_url_prefix|tojson|safe }} + '/jobs/' + encodeURIComponent(param) + '/' + page + '.json';
+    var url = {{ rq_url_prefix|tojson|safe }} + 'jobs/' + encodeURIComponent(param) + '/' + page + '.json';
     return url;
 };
 


### PR DESCRIPTION
Currently, the `RQDashboard` extension does not work properly for apps served as a mount behind a `DispatcherMiddleware` object. Using `url_for` here instead of `extension.url_prefix` allows flask to properly build the full route in this case. See the sample code below for a test (the dashboard is at http://localhost:5000/bar/rq/ in this example).

``` python
from flask import Flask
from rq_dashboard import RQDashboard
from werkzeug.serving import run_simple
from werkzeug.wsgi import DispatcherMiddleware


foo = Flask('foo')
bar = Flask('bar')
RQDashboard(bar)


@foo.route('/')
def hello():
    return 'Hello, World!'


@bar.route('/')
def goodbye():
    return 'Goodbye, World!'


if __name__ == '__main__':
    run_simple('localhost', 5000, DispatcherMiddleware(foo, {'/bar': bar}))
```
