### PR TITLE
let specify the url prefix from outside

### DIFF
--- a/rq_dashboard/app.py
+++ b/rq_dashboard/app.py
@@ -8,4 +8,4 @@ app = Flask(__name__)
 if os.getenv('RQ_DASHBOARD_SETTINGS'):
     app.config.from_envvar('RQ_DASHBOARD_SETTINGS')
 
-RQDashboard(app, '')
+RQDashboard(app, os.getenv('APPLICATION_ROOT', ''))


### PR DESCRIPTION
Blueprints in Flask let you specify a url prefix but the current rq-dasboard pretty much disables this. This PR should fix it.
