### PR TITLE
Provide a configuration option to override the static asset endpoint.

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/base.html
+++ b/rq_dashboard/templates/rq_dashboard/base.html
@@ -6,8 +6,8 @@
   <title>RQ dashboard</title>
 
   {# Le styles -#}
-  <link rel="stylesheet" href="{{ url_for('rq_dashboard.static', filename='css/bootstrap.min.css') }}">
-  <link href="{{ url_for('rq_dashboard.static', filename='css/main.css') }}" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('%s' % static_asset_endpoint, filename='%scss/bootstrap.min.css' % asset_prefix) }}">
+  <link href="{{ url_for('%s' % static_asset_endpoint, filename='%scss/main.css' % asset_prefix) }}" rel="stylesheet">
 </head>
 
 <body>
@@ -21,10 +21,10 @@
 {#- JavaScripts are loaded at the end -#}
 
 {#- Custom JS -#}
-<script src="{{ url_for('rq_dashboard.static', filename='js/jquery.min.js') }}" type="text/javascript"></script>
-<script src="{{ url_for('rq_dashboard.static', filename='js/underscore-min.js') }}" type="text/javascript"></script>
-<script src="{{ url_for('rq_dashboard.static', filename='js/sugar-1.2.1.min.js') }}" type="text/javascript"></script>
-<script src="{{ url_for('rq_dashboard.static', filename='js/bootstrap-tooltip.js') }}" type="text/javascript"></script>
+<script src="{{ url_for('%s' % static_asset_endpoint, filename='%sjs/jquery.min.js' % asset_prefix) }}" type="text/javascript"></script>
+<script src="{{ url_for('%s' % static_asset_endpoint, filename='%sjs/underscore-min.js' % asset_prefix) }}" type="text/javascript"></script>
+<script src="{{ url_for('%s' % static_asset_endpoint, filename='%sjs/sugar-1.2.1.min.js' % asset_prefix) }}" type="text/javascript"></script>
+<script src="{{ url_for('%s' % static_asset_endpoint, filename='%sjs/bootstrap-tooltip.js' % asset_prefix) }}" type="text/javascript"></script>
 <script type="text/javascript">
 {% block inline_js %}{% endblock %}
 </script>

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -139,6 +139,9 @@ def overview(queue_name, page):
         queue=queue,
         page=page,
         queues=Queue.all(),
+        static_asset_endpoint=current_app.config.get(
+            'RQ_STATIC_ENDPOINT', 'rq_dashboard.static'),
+        asset_prefix=current_app.config.get('RQ_ASSET_PREFIX', ''),
         rq_url_prefix=url_for('.overview')
     )
 


### PR DESCRIPTION
The need for this modification came about when attempting to integrate rq-dashboard into an existing Flask application that utilizes Flask-CDN to offload its static assets to a CDN, in combination with a custom authorization provider that protects the rq-dashboard endpoint.

For example, a user successfully authenticates to a Flask application at `portal.example.com` and receives a session cookie for the domain `portal.example.com`. This Flask application implements the Flask-CDN package, which in turn references all static assets at the domain `cdn.example.com`. This authenticated user attempts to access the _protected_ rq-dashboard endpoint. They are able to access the rq_dashboard endpoint, but attempts to access the static assets at `cdn.example.com` fails.

**Scenario 1:** The content origin for `cdn.example.com` is `portal.example.com`. The user is able to load `portal.example.com/rq_dashboard`, but the static assets are accessed from `cdn.example.com/rq_dashboard/static`. Because there is no session cookie for the cdn domain, static asset requests from the CDN to the origin are denied and a broken page is displayed due to the lack of assets.

**Scenario 2:** The content for `cdn.example.com` is statically managed, from a path other than `/rq_dashboard/static` and a custom path needs to be provided.

The addition of the configuration item `RQ_STATIC_ENDPOINT` allows the application developer to specify the Flask applications root `/static` path or other desired application endpoint, so that these assets are not subject to being filtered by the authentication/authorization mechanism. 

The addition of the configuration item `RQ_ASSET_PREFIX` allows the application develops to specify a custom folder prefix if the developer cares to organize, manage, and possibly alter the static assets themselves.
