### PR TITLE
 Provide a configuration option to modify the file paths of static

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/base.html
+++ b/rq_dashboard/templates/rq_dashboard/base.html
@@ -6,8 +6,8 @@
   <title>RQ dashboard</title>
 
   {# Le styles -#}
-  <link rel="stylesheet" href="{{ url_for('rq_dashboard.static', filename='css/bootstrap.min.css') }}">
-  <link href="{{ url_for('rq_dashboard.static', filename='css/main.css') }}" rel="stylesheet">
+  <link rel="stylesheet" href="{{ url_for('rq_dashboard.static', filename='%scss/bootstrap.min.css' % asset_prefix) }}">
+  <link href="{{ url_for('rq_dashboard.static', filename='%scss/main.css' % asset_prefix) }}" rel="stylesheet">
 </head>
 
 <body>
@@ -21,10 +21,10 @@
 {#- JavaScripts are loaded at the end -#}
 
 {#- Custom JS -#}
-<script src="{{ url_for('rq_dashboard.static', filename='js/jquery.min.js') }}" type="text/javascript"></script>
-<script src="{{ url_for('rq_dashboard.static', filename='js/underscore-min.js') }}" type="text/javascript"></script>
-<script src="{{ url_for('rq_dashboard.static', filename='js/sugar-1.2.1.min.js') }}" type="text/javascript"></script>
-<script src="{{ url_for('rq_dashboard.static', filename='js/bootstrap-tooltip.js') }}" type="text/javascript"></script>
+<script src="{{ url_for('rq_dashboard.static', filename='%sjs/jquery.min.js' % asset_prefix) }}" type="text/javascript"></script>
+<script src="{{ url_for('rq_dashboard.static', filename='%sjs/underscore-min.js' % asset_prefix) }}" type="text/javascript"></script>
+<script src="{{ url_for('rq_dashboard.static', filename='%sjs/sugar-1.2.1.min.js' % asset_prefix) }}" type="text/javascript"></script>
+<script src="{{ url_for('rq_dashboard.static', filename='%sjs/bootstrap-tooltip.js' % asset_prefix) }}" type="text/javascript"></script>
 <script type="text/javascript">
 {% block inline_js %}{% endblock %}
 </script>

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -139,6 +139,7 @@ def overview(queue_name, page):
         queue=queue,
         page=page,
         queues=Queue.all(),
+        asset_prefix=current_app.config.get('RQ_DASHBOARD_ASSET_PREFIX', ''),
         rq_url_prefix=url_for('.overview')
     )
 


### PR DESCRIPTION
 assets if they wish to be stored and managed outside of the
 rq_dashboard module.

The need for this modification came about when attempting to integrate rq-dashboard into an existing Flask application that utilizes Flask-CDN to offload its static assets to a CDN. This custom Flask application uses its own authentication/authorization provider to protect the `rq_dashboard` endpoint. This also means that the static assets beneath the `rq_dashboard` endpoint are also protected. Below is a description of a scenario where this is problematic.

A user successfully authenticates to a Flask application at `portal.example.com` and receives a session cookie for the domain `portal.example.com`. This Flask application implements the Flask-CDN package, which in turn references all static assets at the domain `cdn.example.com/static`. This authenticated user attempts to access the protected rq_dashboard endpoint at `portal.example.com/rq_dashboard`. They are able to successfully access the rq_dashboard endpoint, but attempts to access the static assets at `cdn.example.com/rq_dashboard/static` fail. In this example, the backend content origin for `cdn.example.com` is `portal.example.com`. The user is able to load `portal.example.com/rq_dashboard`, but the static assets that are attempting to be accessed via the CDN fail because the request does not contain a session cookie with valid credentials.

In order for the static content of rq-dashboard to be accessed from a location other than from within the protected blueprint of the module, `rq_dashboard.blueprint.static_url_path = '/static'` can be set in order for the application to reference the static assets outside of the blueprint. The addition of the configuration item `RQ_DASHBOARD_ASSET_PREFIX` allows the application developer to specify a custom folder prefix if the developer cares to organize, manage, and possibly alter the static assets or their location. 
