### PR TITLE
Fix broken absolute imports

### DIFF
--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -1,3 +1,3 @@
 # flake8: noqa
-import default_settings
-from web import blueprint
+from . import default_settings
+from .web import blueprint


### PR DESCRIPTION
Most imports in the project are relative imports, but package `rq_dashboard/__init__.py` uses absolute imports, which makes it impossible to either start the dashboard using `cli.py`, import it from a different project (see #88), or even use `rq-dashboard` after building the distribution package. This simple patch solves this problem by changing the imports to relative ones.
