### PR TITLE
Make JSON serialization Python 3 compatible

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -97,7 +97,7 @@ def serialize_job(job):
         ended_at=serialize_date(job.ended_at),
         origin=job.origin,
         result=job._result,
-        exc_info=job.exc_info,
+        exc_info=job.exc_info.decode('utf-8'),
         description=job.description)
 
 
@@ -239,7 +239,7 @@ def list_workers():
         dict(
             name=worker.name,
             queues=serialize_queue_names(worker),
-            state=worker.get_state()
+            state=worker.get_state().decode('utf-8')
         )
         for worker in Worker.all()
     ]


### PR DESCRIPTION
Some job/worker properties fail to serialize to JSON when using Python 3 since they are bytes not strings (`job.exc_info` and `worker.get_state()`). This patch decodes then to strings before serializing.
