### PR TITLE
Explicitly set `static_url_path`

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -30,6 +30,7 @@ blueprint = Blueprint(
     __name__,
     template_folder='templates',
     static_folder='static',
+    static_url_path='/static/rq_dashboard'
 )
 
 


### PR DESCRIPTION
I was having issue with my app where we use `rq_dashboard` where the urls generated in the templates where pointing to my applications static folder and thus not finding the assets necessary.

See [this SO thread](http://stackoverflow.com/a/22152975)
