### PR TITLE
Allow 'cancel' button to remove a job.

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -22,7 +22,7 @@ from math import ceil
 import arrow
 from flask import Blueprint, current_app, render_template, url_for
 from redis import Redis, from_url
-from rq import (Queue, Worker, cancel_job, get_failed_queue, pop_connection,
+from rq import (Queue, Worker, job, get_failed_queue, pop_connection,
                 push_connection, requeue_job)
 
 blueprint = Blueprint(
@@ -146,7 +146,7 @@ def overview(queue_name, page):
 @blueprint.route('/job/<job_id>/cancel', methods=['POST'])
 @jsonify
 def cancel_job_view(job_id):
-    cancel_job(job_id)
+    job.Job.fetch(job_id).delete()
     return dict(status='OK')
 
 


### PR DESCRIPTION
Previously (rq<0.6.0) the behavior of the cancel button wound up entirely removing a job from the queue.  For instance, if you had 5 jobs on the failed queue and selected Cancel on one of them, you would no longer see it in the list of failed jobs and the count of jobs on the failed queue would be reduced to 4.

However, as of this [commit](https://github.com/nvie/rq/commit/5a3bebf85b9196d7fcf6cce656aa4dcc1728a953), the job isn't actually removed from the queue.

To restore this behavior, the proposed patch will wind up calling the [delete](https://github.com/nvie/rq/blob/master/rq/job.py#L485) method of the Job which itself takes care of the cancellation as well as removing it from the queue.
