### PR TITLE
Do not show traceback if job is not failed yet

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -97,7 +97,7 @@ def serialize_job(job):
         ended_at=serialize_date(job.ended_at),
         origin=job.origin,
         result=job._result,
-        exc_info=str(job.exc_info),
+        exc_info=str(job.exc_info) if job.exc_info else None,
         description=job.description)
 
 


### PR DESCRIPTION
Right now for every job there is a "failed xxx hours ago" message with traceback `None`.
