### PR TITLE
Add `url_prefix` and example URL, fix #105

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,7 @@ blueprint directly in the normal way, e.g.:
 
     app = Flask(__name__)
     app.config.from_object(rq_dashboard.default_settings)
-    app.register_blueprint(rq_dashboard.blueprint)
+    app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
 
     @app.route("/")
     def hello():
@@ -89,7 +89,7 @@ blueprint directly in the normal way, e.g.:
         app.run()
 
 
-The ``cli.py:main`` entry point provides a simple working example.
+If you start the Flask app on the default port, you can access the dashboard at http://localhost:5000/rq. The ``cli.py:main`` entry point provides a simple working example.
 
 
 Developing


### PR DESCRIPTION
* Add `url_prefix` to `register_blueprint` so that the static files load. Fix #105
* Add example URL to where the dashboard can be found in the custom Flask app.