### PR TITLE
Added the ability to define URL_PREFIX in Docker startup file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ EXPOSE $PORT
 ENV REDIS_URL redis://redis
 ENV USERNAME rq
 ENV PASSWORD password
+ENV URL_PREFIX /
 
 ENTRYPOINT ["/tini", "--", "/autoexec.sh"]
 CMD ["web"]

--- a/autoexec.sh
+++ b/autoexec.sh
@@ -2,7 +2,7 @@
 set -e
 
 if [ "$1" = 'web' ]; then
-    exec rq-dashboard -p $PORT -u $REDIS_URL --username $USERNAME --password $PASSWORD
+    exec rq-dashboard -p $PORT -u $REDIS_URL --username $USERNAME --password $PASSWORD --url-prefix $URL_PREFIX
 fi
 
 exec "$@"


### PR DESCRIPTION
Is there a more elegant/correct way to allow the rq-dasboard to operate in a different url prefix when running through docker?

In my use case I want to host rq-dashboard in an `/rq` subdirectory behind a ngix reverse proxy using:

```
location /rq {
        proxy_pass http://docker-rq-dashboard/rq;
        proxy_set_header X-Real-IP $remote_addr;
        proxy_set_header   Host $host;
    }
```

If rq-dashboard is NOT started with a $URL_PREFIX all the css and javascript files are loaded from a static address that start from `/static/*.css` and it confuses the reverse proxy.

At least this way I can force flask's `url_for` to use the current url prefix.

Thanks.