### PR TITLE
Fixed ImportError when configuration file is provided using option -c

### DIFF
--- a/rq_dashboard/__main__.py
+++ b/rq_dashboard/__main__.py
@@ -1,0 +1,5 @@
+from .cli import main
+
+
+if __name__ == '__main__':
+    main()

--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import importlib
 import os
+import sys
 
 import click
 from flask import Flask, Response, request
@@ -90,11 +91,13 @@ def make_flask_app(config, username, password, url_prefix):
 @click.option(
     '--interval', default=None, type=int,
     help='Refresh interval in ms')
+@click.option('--path', default='.',
+              help='Specify the import path.')
 def run(
         bind, port, url_prefix, username, password,
         config,
         redis_host, redis_port, redis_password, redis_database, redis_url,
-        interval):
+        interval, path):
     """Run the RQ Dashboard Flask server.
 
     All configuration can be set on the command line or through environment
@@ -106,6 +109,9 @@ def run(
     RQ_DASHBOARD_SETTINGS environment variable.
 
     """
+    if path:
+        sys.path = path.split(':') + sys.path
+
     click.echo('RQ Dashboard version {0}'.format(VERSION))
     app = make_flask_app(config, username, password, url_prefix)
     if redis_url:

--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -91,13 +91,14 @@ def make_flask_app(config, username, password, url_prefix):
 @click.option(
     '--interval', default=None, type=int,
     help='Refresh interval in ms')
-@click.option('--path', default='.',
-              help='Specify the import path.')
+@click.option(
+    '--extra-path', default='.', multiple=True,
+    help='Append specified directories to sys.path')
 def run(
         bind, port, url_prefix, username, password,
         config,
         redis_host, redis_port, redis_password, redis_database, redis_url,
-        interval, path):
+        interval, extra_path):
     """Run the RQ Dashboard Flask server.
 
     All configuration can be set on the command line or through environment
@@ -109,8 +110,8 @@ def run(
     RQ_DASHBOARD_SETTINGS environment variable.
 
     """
-    if path:
-        sys.path = path.split(':') + sys.path
+    if extra_path:
+        sys.path += list(extra_path)
 
     click.echo('RQ Dashboard version {0}'.format(VERSION))
     app = make_flask_app(config, username, password, url_prefix)


### PR DESCRIPTION
`rq-dashboard -c myproject.rq_config`: Gives the following error
```
  File "/Users/voith/Projects/myproject/venv/lib/python3.5/site-packages/rq_dashboard/cli.py", line 110, in run
    app = make_flask_app(config, username, password, url_prefix)
  File "/Users/voith/Projects/myproject/venv/lib/python3.5/site-packages/rq_dashboard/cli.py", line 42, in make_flask_app
    app.config.from_object(importlib.import_module(config))
  File "/Users/voith/Projects/myproject/venv/lib/python3.5/importlib/__init__.py", line 126, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 944, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 222, in _call_with_frames_removed
  File "<frozen importlib._bootstrap>", line 986, in _gcd_import
  File "<frozen importlib._bootstrap>", line 969, in _find_and_load
  File "<frozen importlib._bootstrap>", line 956, in _find_and_load_unlocked
ImportError: No module named 'myproject'
```

I have added `--path` option to specify import path. Default is set to the current directory ('.')

The code has been taken directly from rq: https://github.com/nvie/rq/blob/master/rq/cli/cli.py#L149-L150