### PR TITLE
[#128] Support multiple RQ instances

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/dashboard.html
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.html
@@ -2,7 +2,16 @@
 
 
 {% block content %}
-
+<div class="row" id="rq-instances-row">
+    <div class="span12">
+        <div class="section">
+            <h1>RQ Instances</h1>
+            <p class="intro">Select below the RQ instance that you want to observe.</p>
+            <select id="rq-instances">
+            </select>
+        </div>
+    </div>
+</div>
 <div class="row">
     <div class="span6">
         <div class="section">

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -1,6 +1,8 @@
 var url_for = function(name, param) {
     var url = {{ rq_url_prefix|tojson|safe }};
-    if (name == 'queues') { url += 'queues.json'; }
+    if (name == 'rq-instances') {url += 'rq-instances.json'; }
+    else if (name == 'rq-instance') { url += 'rq-instance/' + encodeURIComponent(param); }
+    else if (name == 'queues') { url += 'queues.json'; }
     else if (name == 'workers') { url += 'workers.json'; }
     else if (name == 'cancel_job') { url += 'job/' + encodeURIComponent(param) + '/cancel'; }
     else if (name == 'requeue_job') { url += 'job/' + encodeURIComponent(param) + '/requeue'; }
@@ -19,6 +21,13 @@ var toRelative = function(universal_date_string) {
 };
 
 var api = {
+    getRqInstances: function(cb) {
+        $.getJSON(url_for('rq-instances'), function(data) {
+            var instances = data.rq_instances;
+            cb(instances);
+        });
+    },
+
     getQueues: function(cb) {
         $.getJSON(url_for('queues'), function(data) {
             var queues = data.queues;
@@ -42,6 +51,38 @@ var api = {
     }
 };
 
+//
+// RQ instances
+//
+(function($) {
+    var $rqInstances = $('#rq-instances');
+
+    var resolve_rq_instances = function() {
+        api.getRqInstances(function(instances) {
+            if (!Array.isArray(instances)) {
+                $('#rq-instances-row').hide();
+                return;
+            }
+            $rqInstances.empty();
+            $.each(instances, function(i, instance) {
+                $rqInstances.append($('<option>', {
+                    value: i,
+                    text: instance
+                  }));
+            });
+        });
+    };
+
+    // Listen for changes on the select
+    $rqInstances.change(function() {
+        var url = url_for('rq-instance', $(this).val());
+        $.post(url, function(data) {});
+    });
+
+    $(document).ready(function() {
+        resolve_rq_instances();
+    });
+})($);
 
 //
 // QUEUES

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -36,7 +36,9 @@ blueprint = Blueprint(
 @blueprint.before_app_first_request
 def setup_rq_connection():
     redis_url = current_app.config.get('REDIS_URL')
-    if redis_url:
+    if isinstance(redis_url, list):
+        current_app.redis_conn = from_url(redis_url[0])
+    elif redis_url:
         current_app.redis_conn = from_url(redis_url)
     else:
         current_app.redis_conn = Redis(
@@ -183,6 +185,23 @@ def compact_queue(queue_name):
     q.compact()
     return dict(status='OK')
 
+@blueprint.route('/rq-instance/<instance_number>', methods=['POST'])
+@jsonify
+def change_rq_instance(instance_number):
+    redis_url = current_app.config.get('REDIS_URL')
+    if not isinstance(redis_url, list):
+        return dict(status='Single RQ. Not Permitted.')
+    if int(instance_number) >= len(redis_url):
+        raise LookupError('Index exceeds RQ list. Not Permitted.')
+    pop_connection()
+    current_app.redis_conn = from_url(redis_url[int(instance_number)])
+    push_rq_connection()
+    return dict(status='OK')
+
+@blueprint.route('/rq-instances.json')
+@jsonify
+def list_instances():
+    return dict(rq_instances=current_app.config.get('REDIS_URL'))
 
 @blueprint.route('/queues.json')
 @jsonify


### PR DESCRIPTION
This pull request resolves #128 **Support multiple RQ instances** and references #18

When using the Flask Blueprint, it is possible to pass an array of Redis URL to the rq-dashboard plugin.

```python
app.config.update(REDIS_URL=['redis://localhost:6379/0', 'redis://localhost:6379/1'])
app.register_blueprint(rq_dashboard.blueprint, url_prefix='/rq')
```

When passing an array of connections, it will appear on the dashboard a new block with a dropdown, which lets changing the RQ instance to be observed.

![screen shot 2017-08-21 at 18 59 33](https://user-images.githubusercontent.com/2593956/29530199-eacc7868-86a2-11e7-8023-ce7ef1f39a27.png)

By default, rq-dashboard will show the information of the first RQ, but selecting another one, will trigger a swap on the backend, so it will start showing the new rq-instance data.