### PR TITLE
Change web background color

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -94,11 +94,15 @@ def make_flask_app(config, username, password, url_prefix):
 @click.option(
     '--extra-path', default='.', multiple=True,
     help='Append specified directories to sys.path')
+@click.option(
+    '--web-background', default='black',
+    help='Background of the web interface')
+
 def run(
         bind, port, url_prefix, username, password,
         config,
         redis_host, redis_port, redis_password, redis_database, redis_url,
-        interval, extra_path):
+        interval, extra_path, web_background):
     """Run the RQ Dashboard Flask server.
 
     All configuration can be set on the command line or through environment
@@ -127,6 +131,8 @@ def run(
         app.config['REDIS_DB'] = redis_database
     if interval:
         app.config['RQ_POLL_INTERVAL'] = interval
+    if web_background:
+        app.config["WEB_BACKGROUND"] = web_background
     app.run(host=bind, port=port)
 
 

--- a/rq_dashboard/default_settings.py
+++ b/rq_dashboard/default_settings.py
@@ -17,3 +17,4 @@ REDIS_DB = 0
 
 RQ_POLL_INTERVAL = 2500  #: Web interface poll period for updates in ms
 DEBUG = False
+WEB_BACKGROUND="black"

--- a/rq_dashboard/templates/rq_dashboard/base.html
+++ b/rq_dashboard/templates/rq_dashboard/base.html
@@ -10,7 +10,7 @@
   <link href="{{ url_for('rq_dashboard.static', filename='css/main.css') }}" rel="stylesheet">
 </head>
 
-<body>
+<body style="background-color:{{config.WEB_BACKGROUND}};">
 
 <div class="container">
 


### PR DESCRIPTION
Added `WEB_BACKGROUND` option throughout the application.
Can be edited as `app.config["WEB_BACKGROUND"]`, or added via cli with the `--web-background` option.
**It defaults to black**, so "backwards compatibility" is preserved :)


Works with all legal css colors:
* "regular colors" - `rq-dashboard --web-background pink`,
* hex colors - `rq-dashboard --web-background "#FFC0CB"`.

<img src="https://i.imgur.com/tasXUKI.png">