### PR TITLE
Redis sentinel support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,10 @@ Run the dashboard standalone, like this:
       -D, --redis-database INTEGER  Database of Redis server
       -u, --redis-url TEXT          Redis URL connection (overrides other
                                     individual settings)
+      --sentinels TEXT              List of sentinel addresses (comma separated),
+                                    in such format <host1>:<port1>,<host2>:<port2>...
+      --master-name TEXT            Only required if using sentinels.
+                                    Tells sentinel what master to query
       --interval INTEGER            Refresh interval in ms
       --help                        Show this message and exit.
 

--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -89,6 +89,12 @@ def make_flask_app(config, username, password, url_prefix):
     '-u', '--redis-url', default=None,
     help='Redis URL connection (overrides other individual settings)')
 @click.option(
+    '--sentinels', default=None, multi=True,
+    help='Array of redis sentinels. Each should be formatted: <host>:<port>')
+@click.option(
+    '--master-name', default=None,
+    help='Name of redis master. Only needed when using sentinels')
+@click.option(
     '--interval', default=None, type=int,
     help='Refresh interval in ms')
 @click.option(
@@ -102,6 +108,7 @@ def run(
         bind, port, url_prefix, username, password,
         config,
         redis_host, redis_port, redis_password, redis_database, redis_url,
+        redis_sentinels, redis_master_name,
         interval, extra_path, web_background):
     """Run the RQ Dashboard Flask server.
 
@@ -129,6 +136,10 @@ def run(
         app.config['REDIS_PASSWORD'] = redis_password
     if redis_database:
         app.config['REDIS_DB'] = redis_database
+    if redis_sentinels:
+        app.config['REDIS_SENTINELS'] = ','.join(redis_sentinels)
+    if redis_master_name:
+        app.config['REDIS_MASTER_NAME'] = redis_master_name
     if interval:
         app.config['RQ_POLL_INTERVAL'] = interval
     if web_background:

--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -89,10 +89,10 @@ def make_flask_app(config, username, password, url_prefix):
     '-u', '--redis-url', default=None,
     help='Redis URL connection (overrides other individual settings)')
 @click.option(
-    '--sentinels', default=None, multi=True,
+    '--redis-sentinels', default=None,
     help='Array of redis sentinels. Each should be formatted: <host>:<port>')
 @click.option(
-    '--master-name', default=None,
+    '--redis-master-name', default=None,
     help='Name of redis master. Only needed when using sentinels')
 @click.option(
     '--interval', default=None, type=int,
@@ -103,13 +103,14 @@ def make_flask_app(config, username, password, url_prefix):
 @click.option(
     '--web-background', default='black',
     help='Background of the web interface')
-
+@click.option(
+    '--debug/--normal', default=False, help='Enter DEBUG mode')
 def run(
         bind, port, url_prefix, username, password,
         config,
         redis_host, redis_port, redis_password, redis_database, redis_url,
         redis_sentinels, redis_master_name,
-        interval, extra_path, web_background):
+        interval, extra_path, web_background, debug):
     """Run the RQ Dashboard Flask server.
 
     All configuration can be set on the command line or through environment
@@ -137,14 +138,14 @@ def run(
     if redis_database:
         app.config['REDIS_DB'] = redis_database
     if redis_sentinels:
-        app.config['REDIS_SENTINELS'] = ','.join(redis_sentinels)
+        app.config['REDIS_SENTINELS'] = redis_sentinels
     if redis_master_name:
         app.config['REDIS_MASTER_NAME'] = redis_master_name
     if interval:
         app.config['RQ_POLL_INTERVAL'] = interval
     if web_background:
         app.config["WEB_BACKGROUND"] = web_background
-    app.run(host=bind, port=port)
+    app.run(host=bind, port=port, debug=debug)
 
 
 def main():

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -41,8 +41,8 @@ def setup_rq_connection():
     if isinstance(redis_url, list):
         current_app.redis_conn = from_url(redis_url[0])
     elif redis_sentinels:
-        redis_master = current_app.config('REDIS_MASTER_NAME')
-        password=current_app.config.get('REDIS_PASSWORD'),
+        redis_master = current_app.config.get('REDIS_MASTER_NAME')
+        password=current_app.config.get('REDIS_PASSWORD')
         db=current_app.config.get('REDIS_DB')
         sentinel_hosts = [tuple(sentinel.split(':', 1))
                           for sentinel in redis_sentinels.split(',')]

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -260,14 +260,6 @@ def list_jobs(queue_name, page):
 @blueprint.route('/workers.json')
 @jsonify
 def list_workers():
-    worker_id = request.args.get("worker_id", None)
-
-    def filtering(worker):
-        if worker_id:
-            return worker_id in worker.name
-        else:
-            return True
-
     def serialize_queue_names(worker):
         return [q.name for q in worker.queues]
 
@@ -278,7 +270,6 @@ def list_workers():
             state=str(worker.get_state())
         )
         for worker in Worker.all()
-        if filtering(worker)
     ]
     return dict(workers=workers)
 

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -22,6 +22,7 @@ from math import ceil
 import arrow
 from flask import Blueprint, current_app, render_template, url_for, request
 from redis import Redis, from_url
+from redis.sentinel import Sentinel
 from rq import (Queue, Worker, cancel_job, get_failed_queue, pop_connection,
                 push_connection, requeue_job)
 
@@ -36,10 +37,18 @@ blueprint = Blueprint(
 @blueprint.before_app_first_request
 def setup_rq_connection():
     redis_url = current_app.config.get('REDIS_URL')
+    redis_sentinels = current_app.config.get('REDIS_SENTINELS')
     if isinstance(redis_url, list):
         current_app.redis_conn = from_url(redis_url[0])
-    elif redis_url:
-        current_app.redis_conn = from_url(redis_url)
+    elif redis_sentinels:
+        redis_master = current_app.config('REDIS_MASTER_NAME')
+        password=current_app.config.get('REDIS_PASSWORD'),
+        db=current_app.config.get('REDIS_DB')
+        sentinel_hosts = [tuple(sentinel.split(':', 1))
+                          for sentinel in redis_sentinels.split(',')]
+
+        sentinel = Sentinel(sentinel_hosts, db=db, password=password)
+        current_app.redis_conn = sentinel.master_for(redis_master)
     else:
         current_app.redis_conn = Redis(
             host=current_app.config.get('REDIS_HOST'),


### PR DESCRIPTION
Added support for Redis Sentinels: `--redis-sentinels` array and `--redis-master-name` can be given, instead of `--redis-host` and `--redis-port`.