### PR TITLE
Add missing blank line to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -162,6 +162,7 @@ Docker
 You can also run the dashboard inside of docker, simply build the image with 
 
 ::
+
     $ make image
 
 and you can then run the image, possibly modifying it with the following environment


### PR DESCRIPTION
Added missing blank line to README.rst for docker command to be displayed correctly