### PR TITLE
Fix broken legacy behaviour with string redis_url

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -4,6 +4,7 @@ Flask
 redis
 rq>=0.3.8
 arrow>=0.12.1
+six>=1.11.0
 
 # Compatibility
 backports.functools_lru_cache; python_version < '3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,5 +15,5 @@ nose==1.3.7
 python-dateutil==2.6.1    # via arrow
 redis==2.10.6
 rq==0.5.3
-six==1.11.0               # via python-dateutil
+six==1.11.0
 werkzeug==0.14.1          # via flask

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -26,6 +26,7 @@ from redis.sentinel import Sentinel
 from rq import (Queue, Worker, cancel_job, get_failed_queue, pop_connection,
                 push_connection, requeue_job)
 from rq.job import Job
+from six import string_types
 
 blueprint = Blueprint(
     'rq_dashboard',
@@ -41,6 +42,8 @@ def setup_rq_connection():
     redis_sentinels = current_app.config.get('REDIS_SENTINELS')
     if isinstance(redis_url, list):
         current_app.redis_conn = from_url(redis_url[0])
+    elif isinstance(redis_url, string_types):
+        current_app.redis_conn = from_url(redis_url)
     elif redis_sentinels:
         redis_master = current_app.config.get('REDIS_MASTER_NAME')
         password = current_app.config.get('REDIS_PASSWORD')


### PR DESCRIPTION
Current implementation doesn't seem to handle the pass of an string as redis_url through the Flask application configuration.

This was an expected (to me) behaviour on 0.3.10, now it seems that it supports multiple redis_url but they need to be provided as a List.