### PR TITLE
Update dependencies and use Python 3 in Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:3.6-slim
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
 		dos2unix \
@@ -6,12 +6,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 		libc-dev \
 	&& rm -rf /var/lib/apt/lists/*
 
-ENV TINI_VERSION v0.13.2
+ENV TINI_VERSION v0.17.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-ENV RQ_VERSION 0.7.1
-RUN pip install rq==$RQ_VERSION
+ENV RQ_VERSION 0.10.0
+RUN pip3 install rq==$RQ_VERSION
 
 ADD autoexec.sh /
 RUN dos2unix /autoexec.sh
@@ -20,8 +20,8 @@ RUN chmod a+x /autoexec.sh
 RUN mkdir /app
 WORKDIR /app
 ADD . /app
-RUN pip install -r /app/requirements.txt
-RUN python setup.py develop
+RUN pip3 install -r /app/requirements.txt
+RUN python3 setup.py develop
 
 ENV PORT 80
 EXPOSE $PORT

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,15 +5,17 @@
 #    pip-compile --output-file requirements.txt requirements.in
 #
 arrow==0.12.1
-backports.functools-lru-cache==1.4 ; python_version < "3.3"
+backports.functools-lru-cache==1.5 ; python_version < "3.3"
 click==6.7
 flask==0.12.2
 itsdangerous==0.24        # via flask
 jinja2==2.10              # via flask
 markupsafe==1.0           # via jinja2
 nose==1.3.7
-python-dateutil==2.6.1    # via arrow
+python-dateutil==2.6.1 ; python_version < "2.7"   # via arrow
+python-dateutil==2.7.0 ; python_version >= "2.7"  # via arrow
 redis==2.10.6
-rq==0.5.3
+rq==0.8.0  ; python_version < "2.7"
+rq==0.10.0 ; python_version >= "2.7"
 six==1.11.0
 werkzeug==0.14.1          # via flask


### PR DESCRIPTION
I've had compatibility issues with the current setup, the clients were using much more recent rq versions. (Mostly the different time format, reported in many issues, one of them is https://github.com/rq/rq/issues/927.)
This fixed it for me, I hope it doesn't break anything.