### PR TITLE
Prefix rq-dashboard's configuration keys

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -145,9 +145,9 @@ def run(
     if interval:
         app.config['RQ_POLL_INTERVAL'] = interval
     if web_background:
-        app.config["WEB_BACKGROUND"] = web_background
+        app.config['RQ_WEB_BACKGROUND'] = web_background
     if delete_jobs:
-        app.config["DELETE_JOBS"] = delete_jobs
+        app.config['RQ_DELETE_JOBS'] = delete_jobs
 
     app.run(host=bind, port=port, debug=debug)
 

--- a/rq_dashboard/default_settings.py
+++ b/rq_dashboard/default_settings.py
@@ -17,5 +17,5 @@ REDIS_DB = 0
 
 RQ_POLL_INTERVAL = 2500  #: Web interface poll period for updates in ms
 DEBUG = False
-WEB_BACKGROUND = "black"
-DELETE_JOBS = False
+RQ_WEB_BACKGROUND = "black"
+RQ_DELETE_JOBS = False

--- a/rq_dashboard/templates/rq_dashboard/base.html
+++ b/rq_dashboard/templates/rq_dashboard/base.html
@@ -10,7 +10,7 @@
   <link href="{{ url_for('rq_dashboard.static', filename='css/main.css') }}" rel="stylesheet">
 </head>
 
-<body style="background-color:{{config.WEB_BACKGROUND}};">
+<body style="background-color:{{config.RQ_WEB_BACKGROUND}};">
 
 <div class="container">
 

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -163,7 +163,7 @@ def overview(queue_name, page):
 @blueprint.route('/job/<job_id>/cancel', methods=['POST'])
 @jsonify
 def cancel_job_view(job_id):
-    if current_app.config.get('DELETE_JOBS'):
+    if current_app.config.get('RQ_DELETE_JOBS'):
         Job.fetch(job_id).delete()
     else:
         cancel_job(job_id)


### PR DESCRIPTION
rq-dashboard is built as a blueprint and, as such, prepared to be integrated into an existing Flask application.

Thus, it should prefix its configuration keys to distinguish them from the application's configuration keys.

I've followed the lead of `RQ_POLL_INTERVAL` here, but `RQ_DASHBOARD_` as the prefix would feel even cleaner to me.

I'm aware that this change is backwards-incompatible, but I don't like my applications' config namespaces polluted/overshadowed by extensions.

Let me know what you think. :)

PS: 15abefdf5c4bf3664959424358b1edc5ce95b1ac is the commit that introduced the more recent `WEB_BACKGROUND` configuration key, which is not that unlikely to clash with what the app rq-dashboard is integrated to could use.