### PR TITLE
[Issue-127] Enable copy-paste in Jobs table

### DIFF
--- a/rq_dashboard/static/css/main.css
+++ b/rq_dashboard/static/css/main.css
@@ -118,3 +118,13 @@ span.loading {
     font-size: .8em;
     color: #555;
 }
+
+#alert-fixed {
+    position: fixed;
+    top: 20px;
+    left: 20px;
+    width: 25%;
+    z-index:9999;
+    text-align: center;
+    display: none;
+}

--- a/rq_dashboard/templates/rq_dashboard/base.html
+++ b/rq_dashboard/templates/rq_dashboard/base.html
@@ -12,6 +12,10 @@
 
 <body style="background-color:{{config.WEB_BACKGROUND}};">
 
+<div id="alert-fixed" class="alert alert-error">
+  <strong>Warning!</strong> Selection pauses information refresh
+</div>
+
 <div class="container">
 
     {% block content %}{% endblock %}

--- a/rq_dashboard/templates/rq_dashboard/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/dashboard.js
@@ -316,6 +316,11 @@ var api = {
     };
 
     var refresh_table = function() {
+        if (window.getSelection().toString()) {
+            $('#alert-fixed').show();
+            return;
+        }
+        $('#alert-fixed').hide();
         $('span.loading').fadeIn('fast');
         reload_table(function() {
             $('span.loading').fadeOut('fast');


### PR DESCRIPTION
Simple but effective solution for selecting, copy and paste. Enabled
only for the Jobs table.
By using window.getSelection() we can retrieve a selection by the user,
so if there is a selection a refresh is prevented. Once the selection is
cleared, normal refreshing will happen.

This PR solves #127