### PR TITLE
Sort list of workers.

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -292,7 +292,7 @@ def list_workers():
     def serialize_queue_names(worker):
         return [q.name for q in worker.queues]
 
-    workers = [
+    workers = sorted((
         dict(
             name=worker.name,
             queues=serialize_queue_names(worker),
@@ -300,8 +300,8 @@ def list_workers():
             current_job=serialize_current_job(
                 worker.get_current_job()),
         )
-        for worker in Worker.all()
-    ]
+        for worker in Worker.all()),
+        key=lambda w: (w['state'], w['name']))
     return dict(workers=workers)
 
 


### PR DESCRIPTION
The list of worker instances is displayed in non-deterministic order and
changes every time the list refreshes. This makes it hard to follow the
progress of a specific worker instance between AJAX updates.

This change has the `workers.json` view return the list of worker instances
in a fixed order, based on its state, followed by its name. This way the
busy instances are listed up top.