### PR TITLE
Fix jobs table break if name too long

### DIFF
--- a/rq_dashboard/static/css/main.css
+++ b/rq_dashboard/static/css/main.css
@@ -56,6 +56,11 @@ table#queues {
     /*width: 300px;*/
 }
 
+table#jobs {
+  table-layout: fixed;
+  word-wrap: break-word;
+}
+
 table#jobs td.actions a {
     margin-right: 8px;
     margin-bottom: 8px;


### PR DESCRIPTION
Solve #168 

The screenshot after changing:
![screen shot 2019-01-16 at 9 26 43 am](https://user-images.githubusercontent.com/2952415/51220620-eaeddf00-1970-11e9-80e8-5db3585d71d0.png)
