### PR TITLE
Add rq-dashboard flask logging verbosity option

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -16,6 +16,7 @@ Jonathan Hitchcock <jonathan.hitchcock@gmail.com>
 Joohwan Oh <joohwan.oh@outlook.com>
 Klimin Mike <klinkin@gmail.com>
 Nathan Mudie <nathan.mudie@gmail.com>
+Nicholas Mei <nicholas.mei@outlook.com>
 Onilton Maciel <oniltonmaciel@gmail.com>
 Pedro Vicente <pedrovfer@gmail.com>
 Rad Cirskis <nad2000@gmail.com>

--- a/README.rst
+++ b/README.rst
@@ -74,6 +74,7 @@ Run the dashboard standalone, like this:
       --web-background TEXT           Background of the web interface
       --delete-jobs TEXT              Delete jobs instead of cancel
       --debug / --normal              Enter DEBUG mode
+      --verbose-logging TEXT          Make Flask logger verbose
       --help                          Show this message and exit.
 
 


### PR DESCRIPTION
This commit adds the `--verbose_logging` option to
the rq-dashboard cli. This option will be set to
false by default. Using this option will result
in verbose werkzeug messages.

e.g. `"GET /index.html HTTP/1.1" 200`

Relates to: #100 and #149