### PR TITLE
Use a CSRF token if needed

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/scripts/dashboard.js
+++ b/rq_dashboard/templates/rq_dashboard/scripts/dashboard.js
@@ -150,6 +150,29 @@ var modalConfirm = function(action, cb) {
 })($);
 
 (function ($) {
+    function getCookie(cname) {
+        var name = cname + "=";
+        var decodedCookie = decodeURIComponent(document.cookie);
+        var ca = decodedCookie.split(';');
+        for(var i = 0; i <ca.length; i++) {
+            var c = ca[i];
+            while (c.charAt(0) == ' ') {
+                c = c.substring(1);
+            }
+            if (c.indexOf(name) == 0) {
+                return c.substring(name.length, c.length);
+            }
+        }
+        return "";
+    }
+    var CSRF = getCookie("_csrf_token");
+    if (CSRF != ""){
+        $.ajaxSetup({
+            headers: {
+                'X-CSRFToken': CSRF
+            }
+        });
+    }
     $('#autorefresh-switch').change(function() {
         if ($('#autorefresh-switch').prop('checked')){
             AUTOREFRESH_FLAG = 1;


### PR DESCRIPTION
Setup jquery AJAX header in case of CSRF using cookie
In my case I use "_csrf_token" for the cookie and 'X-CSRFToken' for the header.
Base application use flask_seasurf.