### PR TITLE
Correct URL for viewing the queue. Do not use a hardcoded one, use ur…

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/scripts/job.js
+++ b/rq_dashboard/templates/rq_dashboard/scripts/job.js
@@ -53,10 +53,10 @@
         var url = url_for('delete_job', job_id);
 
         modalConfirm('delete job', function() {
-            $.post(url);
-            $(location).attr("href", '/view/queues');
+            $.post(url, {}, function(){
+                $(location).attr("href", url_for('queues_view'));
+            });
         });
-
         return false;
     });
 


### PR DESCRIPTION
Correct mistake for delete-job function in job managment.
Hardcoded URL redirection.
redirection just after the $.post() could not work.