### PR TITLE
fix: do not trigger multiple refresh loops when API returns an error

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/scripts/job.js
+++ b/rq_dashboard/templates/rq_dashboard/scripts/job.js
@@ -12,10 +12,6 @@
             }
             onJobLoaded(job, done);
         });
-
-        if (done !== undefined) {
-            done();
-        }
     };
 
     var onJobLoaded = function(job, done) {
@@ -35,6 +31,10 @@
         }
         html += template({d: job}, {variable: 'd'});
         $job_data[0].innerHTML = html;
+
+        if (done !== undefined) {
+            done();
+        }
     };
 
     var refresh_loop = function() {


### PR DESCRIPTION
On the single job page view, if the API returns an error when refreshing the page, not one but two calls to `done()` are triggered, which turns into a DDOS after a few minutes if the API fails consistently.

This PR fixes that so that only one call to `done()` is triggered in any case.