### PR TITLE
add available worker properties

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -529,7 +529,7 @@ def job_info(instance_number, job_id):
 @blueprint.route("/<int:instance_number>/data/workers.json")
 @jsonify
 def list_workers(instance_number):
-    def (worker):
+    def serialize_queue_names(worker):
         return [q.name for q in worker.queues]
 
     workers = sorted(

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -174,7 +174,7 @@ def serialize_job(job):
     )
 
 
-def serialize_(job):
+def serialize_current_job(job):
     if job is None:
         return "idle"
     return dict(

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -174,7 +174,7 @@ def serialize_job(job):
     )
 
 
-def serialize_current_job(job):
+def serialize_(job):
     if job is None:
         return "idle"
     return dict(
@@ -529,16 +529,22 @@ def job_info(instance_number, job_id):
 @blueprint.route("/<int:instance_number>/data/workers.json")
 @jsonify
 def list_workers(instance_number):
-    def serialize_queue_names(worker):
+    def (worker):
         return [q.name for q in worker.queues]
 
     workers = sorted(
         (
             dict(
                 name=worker.name,
+                pid=worker.pid,
                 queues=serialize_queue_names(worker),
                 state=str(worker.get_state()),
                 current_job=serialize_current_job(worker.get_current_job()),
+                last_heartbeat=worker.last_heartbeat,
+                birth_date=worker.birth_date,
+                successful_job_count=worker.successful_job_count,
+                failed_job_count=worker.failed_job_count,
+                total_working_time=worker.total_working_time,
                 version=getattr(worker, "version", ""),
                 python_version=getattr(worker, "python_version", ""),
             )


### PR DESCRIPTION
according the rq documentation a worker have following properties:
* hostname - the host where this worker is run
* pid - worker’s process ID
* queues - queues on which this worker is listening for jobs
* state - possible states are suspended, started, busy and idle
* current_job - the job it’s currently executing (if any)
* last_heartbeat - the last time this worker was seen
* birth_date - time of worker’s instantiation
* successful_job_count - number of jobs finished successfully
* failed_job_count - number of failed jobs processed
* total_working_time - amount of time spent executing jobs, in seconds

these properties can also be used in the dashboard.