### PR TITLE
Add missed colon when construct url from password env

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -233,7 +233,7 @@ def run(
             if redis_port:
                 netloc = "%s:%s" % (netloc, redis_port)
         if redis_password:
-            netloc = urlquote(redis_password) + "@" + netloc
+            netloc = ":" + urlquote(redis_password) + "@" + netloc
         path = ""
         if redis_master_name:
             path += "/%s" % urlquote(redis_master_name)


### PR DESCRIPTION
When we use old "RQ_DASHBOARD_REDIS_PASSWORD", final URL is not formed correctly. Missing colon before the password and password allways wrong.