### PR TITLE
Add decoding for params from url

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -66,9 +66,9 @@ def setup_rq_connection():
     redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
     if isinstance(redis_url, string_types):
         current_app.config["RQ_DASHBOARD_REDIS_URL"] = (redis_url,)
-        _, current_app.redis_conn = from_url((redis_url,)[0])
+        _, current_app.redis_conn = from_url((redis_url,)[0], client_options = dict(decode_components=True))
     elif isinstance(redis_url, (tuple, list)):
-        _, current_app.redis_conn = from_url(redis_url[0])
+        _, current_app.redis_conn = from_url(redis_url[0], client_options = dict(decode_components=True))
     else:
         raise RuntimeError("No Redis configuration!")
 
@@ -79,7 +79,7 @@ def push_rq_connection():
     if new_instance_number is not None:
         redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
         if new_instance_number < len(redis_url):
-            _, new_instance = from_url(redis_url[new_instance_number])
+            _, new_instance = from_url(redis_url[new_instance_number], client_options = dict(decode_components=True))
         else:
             raise LookupError("Index exceeds RQ list. Not Permitted.")
     else:


### PR DESCRIPTION
If password on the redis server uses characters that require encoding in the URL ("?", "*"), then the decoding will not happen and the password will always be incorrect. Password encoding is always carried out, therefore, decoding should also always be done.