### PR TITLE
Fix for click error

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -108,7 +108,7 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
 @click.option(
     "-u",
     "--redis-url",
-    default=None,
+    default=[],
     multiple=True,
     help="Redis URL. Can be specified multiple times. Default: redis://127.0.0.1:6379",
 )
@@ -134,7 +134,7 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
 )
 @click.option(
     "--extra-path",
-    default=".",
+    default=["."],
     multiple=True,
     help="Append specified directories to sys.path",
 )


### PR DESCRIPTION
Since version 8 of the click, the default value for the parameter with the multiple flag cannot be None.
This causes an exception
ValueError: 'default' must be a list when 'multiple' is true.

https://click.palletsprojects.com/en/8.0.x/changes/#version-8-0-0
"The default value for a parameter with nargs > 1 and multiple=True must be a list of tuples. #1649"