### PR TITLE
add custom RQ job class capability with --job-class

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ environment variables with prefix `RQ_DASHBOARD_*`:
     - RQ_DASHBOARD_REDIS_URL=redis://<redis:6379>
     - RQ_DASHBOARD_USERNAME=rq
     - RQ_DASHBOARD_PASSWORD=password
+    - RQ_DASHBOARD_JOB_CLASS=mypackage.CustomJobClass
 
 See more info on how to pass environment variables in [Docker documentation](https://docs.docker.com/engine/reference/commandline/run/#set-environment-variables--e---env---env-file)
 
@@ -79,6 +80,8 @@ Options:
                                   path)
   -u, --redis-url TEXT            Redis URL. Can be specified multiple times.
                                   Default: redis://127.0.0.1:6379
+  -j, --job-class TEXT            RQ Job class to use. It will be imported at
+                                  runtime, so it must be installed.
   --poll-interval, --interval INTEGER
                                   Refresh interval in ms
   --extra-path TEXT               Append specified directories to sys.path

--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -113,6 +113,12 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
     help="Redis URL. Can be specified multiple times. Default: redis://127.0.0.1:6379",
 )
 @click.option(
+    "-j",
+    "--job-class",
+    default=None,
+    help="RQ Job class to use. It will be imported at runtime, so it must be installed.",
+)
+@click.option(
     "--redis-sentinels",
     default=None,
     hidden=True,
@@ -166,6 +172,7 @@ def run(
     redis_password,
     redis_database,
     redis_url,
+    job_class,
     redis_sentinels,
     redis_master_name,
     poll_interval,
@@ -196,6 +203,8 @@ def run(
         app.config["RQ_DASHBOARD_REDIS_URL"] = redis_url
     else:
         app.config["RQ_DASHBOARD_REDIS_URL"] = "redis://127.0.0.1:6379"
+    if job_class:
+        app.config["RQ_DASHBOARD_JOB_CLASS"] = job_class
     if redis_host:
         app.config["DEPRECATED_OPTIONS"].append("--redis-host")
     if redis_port:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -107,6 +107,22 @@ class BasicTestCase(unittest.TestCase):
         w.register_death()
 
 
+class CustomRqClassTestCase(BasicTestCase):
+    def setUp(self):
+        super().setUp()
+        self.app.config['RQ_DASHBOARD_JOB_CLASS'] = 'rq.job.Job'
+
+    def test_invalid_job_class(self):
+        self.app.config['RQ_DASHBOARD_JOB_CLASS'] = 'rq.job.NotAJobClass'
+
+        with self.assertRaises(AttributeError) as ae:
+            self.client.get('/0/data/queues.json')
+
+        self.assertIn('NotAJobClass', str(ae.exception))
+
+
+
 __all__ = [
     'BasicTestCase',
+    'CustomRqClassTestCase'
 ]


### PR DESCRIPTION
## Description

Hello! This PR adds the job class capability to `rq-dashboard`. Please let me know what additional sort of unit tests you'd expect to see; I've formatted with isort and black and ensured pytest and flake8 are passing.

For my company's internal implementation of RQ we use a custom job class as described here:

https://python-rq.org/docs/workers/#worker-arguments

The way the RQ API works, you essentially need to pass this every time you construct an object (there's no global variable for this).

Also, not every function in RQ is capable of respecting this setting. In particular, rq-dashboard uses `requeue_job` which is incapable of respecting the setting so I replaced it's usage.

This PR would add the capability to specify this according to what I perceive to be the pattern in the repo. Internally, RQ accepts this parameter as a string - `rq-dashboard` would too, if this is accepted, which I think is the simplest way to specify it for the operator.
