### PR TITLE
Return password mask for instance_list

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -255,7 +255,7 @@ def queues_overview(instance_number):
             render_template(
                 "rq_dashboard/queues.html",
                 current_instance=instance_number,
-                instance_list=current_app.config.get("RQ_DASHBOARD_REDIS_URL"),
+                instance_list=escape_format_instance_list(current_app.config.get("RQ_DASHBOARD_REDIS_URL")),
                 queues=Queue.all(),
                 rq_url_prefix=url_for(".queues_overview"),
                 rq_dashboard_version=rq_dashboard_version,
@@ -280,7 +280,7 @@ def workers_overview(instance_number):
         render_template(
             "rq_dashboard/workers.html",
             current_instance=instance_number,
-            instance_list=current_app.config.get("RQ_DASHBOARD_REDIS_URL"),
+            instance_list=escape_format_instance_list(current_app.config.get("RQ_DASHBOARD_REDIS_URL")),
             workers=Worker.all(),
             rq_url_prefix=url_for(".queues_overview"),
             rq_dashboard_version=rq_dashboard_version,
@@ -316,7 +316,7 @@ def jobs_overview(instance_number, queue_name, registry_name, per_page, page):
         render_template(
             "rq_dashboard/jobs.html",
             current_instance=instance_number,
-            instance_list=current_app.config.get("RQ_DASHBOARD_REDIS_URL"),
+            instance_list=escape_format_instance_list(current_app.config.get("RQ_DASHBOARD_REDIS_URL")),
             queues=Queue.all(),
             queue=queue,
             per_page=per_page,
@@ -342,7 +342,7 @@ def job_view(instance_number, job_id):
         render_template(
             "rq_dashboard/job.html",
             current_instance=instance_number,
-            instance_list=current_app.config.get("RQ_DASHBOARD_REDIS_URL"),
+            instance_list=escape_format_instance_list(current_app.config.get("RQ_DASHBOARD_REDIS_URL")),
             id=job.id,
             rq_url_prefix=url_for(".queues_overview"),
             rq_dashboard_version=rq_dashboard_version,


### PR DESCRIPTION
# Description

Currently, the dashboard displays the Redis password (which is part of the URL) in plain text, e.g.,

<img width="1478" alt="Screenshot 2023-07-14 at 07 55 33" src="https://github.com/Parallels/rq-dashboard/assets/1479325/02ae4964-7f53-4bd4-9bf6-dc1d65844c85">

Return the masked URL instead to show in the instance list:

<img width="1478" alt="Screenshot 2023-07-14 at 08 03 27" src="https://github.com/Parallels/rq-dashboard/assets/1479325/e09eaac5-b732-46ec-9c1b-25fb8bc9b06c">

This is the rebased PR #377 by @mastervolkov (since I don't have write access to push to that PR directly).

Fixes #359 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works