### PR TITLE
Update blueprint usage to explicitly call `rq_dashboard.web.setup_rq_connection` as of v0.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ import rq_dashboard
 
 app = Flask(__name__)
 app.config.from_object(rq_dashboard.default_settings)
+rq_dashboard.web.setup_rq_connection(app)
 app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
 
 @app.route("/")


### PR DESCRIPTION
# Description

With Flask 2.3.x no longer supporting
`@blueprint.before_app_first_request`,
`rq_dashboard.web.setup_rq_connection` needs to be explicitly called on application setup.

The code has only been adjusted for CLI usage, not for blueprint usage.

Since I don't see another way at this point to make that call automatically with Flask 2.3.x or greater, I've "just" updated the respective section in the README.

This is not as nice as before, and looking at other Flask extensions the API would probably look more common if it would be `rq_dashboard.init_app` instead.

Fixes #464.


## Type of change

- [x] Documentation Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] This change requires a documentation update

(I guess?)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- (n/a) I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works