### PR TITLE
Fix Empty Queue operation for Registries that has no exists jobs

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -152,6 +152,9 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
     hidden=True,
     help="[DEPRECATED] Delete jobs instead of cancel",
 )
+@click.option(
+    "--disable-delete", is_flag=True, default=False, help="Disable delete jobs, clean up registries"
+)
 @click.option("--debug/--normal", default=False, help="Enter DEBUG mode")
 @click.option(
     "-v", "--verbose", is_flag=True, default=False, help="Enable verbose logging"
@@ -178,6 +181,7 @@ def run(
     web_background,
     debug,
     delete_jobs,
+    disable_delete,
     verbose,
     json,
 ):
@@ -252,7 +256,9 @@ def run(
             url,
         )
         app.config["RQ_DASHBOARD_REDIS_URL"] = url
-        
+
+    app.config["RQ_DASHBOARD_DISABLE_DELETE"] = disable_delete
+
     if json:
         service_config.serializer = JSONSerializer
 

--- a/rq_dashboard/templates/rq_dashboard/job.html
+++ b/rq_dashboard/templates/rq_dashboard/job.html
@@ -6,14 +6,16 @@
         <span class="col-10">
             <h2><strong>Job ID</strong>: {{ id }}</h2>
         </span>
-            
+
         <span class="col-2">
             <button id="requeue-job-btn" class="btn btn-outline-warning btn-sm" style="display: none">Requeue</button>
+            {% if enable_delete %}
             <button id="delete-job-btn" class="btn btn-outline-danger btn-sm">Delete</button>
+            {% endif %}
         </span>
     </div>
     <div id="job-data" class="row"></div>
-    
+
 
     <script name="job-info" type="text/template">
 

--- a/rq_dashboard/templates/rq_dashboard/jobs.html
+++ b/rq_dashboard/templates/rq_dashboard/jobs.html
@@ -29,9 +29,11 @@
     </div>
 
     <p class="intro">
+        {% if enable_delete %}
         <a href="{{ url_for('rq_dashboard.empty_queue', queue_name=queue.name, registry_name=registry_name) }}" id="empty-btn"
             class="btn btn-outline-danger btn-sm" style="float: right" data-toggle="tooltip"
             title="Remove all jobs from this queue (<b>destructive</b>)" data-html=true>Empty queue</a>
+        {% endif %}
         {% if registry_name == 'queued' %}
         <a href="{{ url_for('rq_dashboard.compact_queue', queue_name=queue.name) }}" id="compact-btn"
             class="btn btn-outline-success btn-sm" style="float: right; margin-right: 8px;" data-toggle="tooltip"
@@ -76,7 +78,9 @@
                 <% if (d.exc_info) { %>
                 <a href="#" data-role="requeue-job-btn" class="btn btn-outline-warning btn-sm btn-block">Requeue</a>
                 <% } %>
+                {% if enable_delete %}
                 <a href="#" data-role="delete-job-btn" class="btn btn-outline-danger btn-sm">Delete</a>
+                {% endif %}
             </td>
         </tr>
     </script>


### PR DESCRIPTION
# Description

There is some cases when Registry can contain non exist job. And we have fix for that in master: https://github.com/Parallels/rq-dashboard/commit/0b6823aa5604d31afb2973a3a024fb3580552214

This fix adds for Empty Queue operation the possibility to remove such non exist job from Registries.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [X] I have performed a self-review of my own code
- [X] My changes generate no new warnings
