### PR TITLE
Fix: Enabling username and passwords to be obfuscated

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -278,9 +278,9 @@ def get_queue_registry_jobs_count(queue_name, registry_name, offset, per_page):
 
 def escape_format_instance_list(url_list):
     if isinstance(url_list, (list, tuple)):
-        url_list = [re.sub(r"://:[^@]*@", "://:***@", x) for x in url_list]
+        url_list = [re.sub(r":\/\/[^@]*@", "://***:***@", x) for x in url_list]
     elif isinstance(url_list, string_types):
-        url_list = [re.sub(r"://:[^@]*@", "://:***@", url_list)]
+        url_list = [re.sub(r":\/\/[^@]*@", "://***:***@", url_list)]
     return url_list
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -5,6 +5,7 @@ import redis
 from rq import Queue, Worker, pop_connection, push_connection
 
 from rq_dashboard.cli import make_flask_app
+from rq_dashboard.web import escape_format_instance_list
 
 
 HTTP_OK = 200
@@ -105,6 +106,20 @@ class BasicTestCase(unittest.TestCase):
         else:
             self.assertEqual('', data['workers'][0]['version'])
         w.register_death()
+
+
+    def test_instance_escaping(self):
+        expected_redis_instance = "redis://***:***@redis.example.com:6379"
+        self.assertEqual(
+            escape_format_instance_list(
+                [
+                    "redis://myuser:secretpassword@redis.example.com:6379",
+                    "redis://:secretpassword@redis.example.com:6379",
+                    "redis://:@redis.example.com:6379",
+                ]
+            ),
+            [expected_redis_instance, expected_redis_instance, expected_redis_instance],
+        )
 
 
 __all__ = [


### PR DESCRIPTION
# Description

Fixed the regex to obfuscate the redis username and password. Currently this regex only works on redis password when username is not provided.

Fixes # (issue)

Broken regex on redis url

## Type of change

Please delete options that are not relevant.

- [ ] Documentation Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly 
    None exists
- [x] I have added tests that prove my fix is effective or that my feature works