### PR TITLE
Check if RQ_DASHBOARD_REDIS_URL is already populated

### DIFF
--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -202,10 +202,11 @@ def run(
     click.echo("RQ Dashboard version {}".format(VERSION))
     app = make_flask_app(config, username, password, url_prefix)
     app.config["DEPRECATED_OPTIONS"] = []
-    if redis_url:
-        app.config["RQ_DASHBOARD_REDIS_URL"] = redis_url
-    else:
-        app.config["RQ_DASHBOARD_REDIS_URL"] = "redis://127.0.0.1:6379"
+    if app.config.get("RQ_DASHBOARD_REDIS_URL") is None:
+        if redis_url:
+            app.config["RQ_DASHBOARD_REDIS_URL"] = redis_url
+        else:
+            app.config["RQ_DASHBOARD_REDIS_URL"] = "redis://127.0.0.1:6379"
     if redis_host:
         app.config["DEPRECATED_OPTIONS"].append("--redis-host")
     if redis_port:


### PR DESCRIPTION
# Description
RQ_DASHBOARD_REDIS_URL is getting repopulated after make_flask_app() method call with the default value when using RQ_DASHBOARD_SETTINGS option for giving path to config file.

Fixes # (issue)
Added a NULL check for app.config["RQ_DASHBOARD_REDIS_URL"] before populating it with redis_url or default value

## Type of change
Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly

Please let me know where I need to upload the CHANGELOG.md, I do not see it in the repo