### PR TITLE
Fix: Add missing connection parameter for jobs with dependencies

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -620,7 +620,7 @@ def job_info(instance_number, job_id):
         status = []
         for dep_id in dep_ids:
             try:
-                _ = Job.fetch(dep_id, serializer=config.serializer)
+                _ = Job.fetch(dep_id, serializer=config.serializer, connection=current_app.redis_conn)
                 status.append('active')
             except NoSuchJobError:
                 status.append('expired')


### PR DESCRIPTION
# Description

Fixes display of RQ tasks that have other task they depend on. Connection parameter was missing in code that fetches dependencies. It is required as of RQ 2.0 (see #495). 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [ x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works

## Testing

hello.py
```python
from redis import Redis
from rq.queue import Queue

from tasks import download, review

redis_conn = Redis()
q = Queue("default", connection=redis_conn)


def main():
    download_job = q.enqueue(download, "Filename.txt")
    review_job = q.enqueue(review, args=[download_job.id], depends_on=download_job)


if __name__ == "__main__":
    main()
```
tasks.py
```python
from redis import Redis
from rq.job import Job


def download(name):
    return f"{name} Downloaded "


def review(job_id):
    download_job = Job.fetch(job_id, connection=Redis())
    result = download_job.return_value()
    if result:
        download_result = result + "and Reviewed"
        return download_result
    return "no result"
```

Run `hello.py` and open `review` job in RQ-Dashboard. 
