### PR TITLE
Support passing password for sentinel and redis separately.

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -76,9 +76,9 @@ def setup_rq_connection(current_app):
     redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
     if isinstance(redis_url, string_types):
         current_app.config["RQ_DASHBOARD_REDIS_URL"] = (redis_url,)
-        _, current_app.redis_conn = from_url((redis_url,)[0])
+        _, current_app.redis_conn = from_url((redis_url,)[0], sentinel_options={'password': current_app.config.get('RQ_DASHBOARD_REDIS_SENTINEL_PASSWORD')}, client_options={'password': current_app.config.get('RQ_DASHBOARD_REDIS_PASSWORD')})
     elif isinstance(redis_url, (tuple, list)):
-        _, current_app.redis_conn = from_url(redis_url[0])
+        _, current_app.redis_conn = from_url(redis_url[0], sentinel_options={'password': current_app.config.get('RQ_DASHBOARD_REDIS_SENTINEL_PASSWORD')}, client_options={'password': current_app.config.get('RQ_DASHBOARD_REDIS_PASSWORD')})
     else:
         raise RuntimeError("No Redis configuration!")
 
@@ -89,7 +89,7 @@ def push_rq_connection():
     if new_instance_number is not None:
         redis_url = current_app.config.get("RQ_DASHBOARD_REDIS_URL")
         if new_instance_number < len(redis_url):
-            _, new_instance = from_url(redis_url[new_instance_number])
+            _, new_instance = from_url(redis_url[new_instance_number], sentinel_options={'password': current_app.config.get('RQ_DASHBOARD_REDIS_SENTINEL_PASSWORD')}, client_options={'password': current_app.config.get('RQ_DASHBOARD_REDIS_PASSWORD')})
         else:
             raise LookupError("Index exceeds RQ list. Not Permitted.")
     else:


### PR DESCRIPTION
# Description

This adds the possibility to configure the password for sentinel and redis as separate environment variables.

Why was this added? Because passing passwords via the `redis+sentinel` URI string did not work.

Fixes #411

New usage example:
```python
app.config.update(
    RQ_DASHBOARD_REDIS_URL=os.getenv("REDIS_SENTINEL_URL", "redis+sentinel://127.0.0.1:26379,127.0.0.1:36379/mymaster/0")
    RQ_DASHBOARD_REDIS_PASSWORD=os.getenv("REDIS_PASSWORD")
    RQ_DASHBOARD_REDIS_SENTINEL_PASSWORD=os.getenv("REDIS_SENTINEL_PASSWORD")
)
rq_dashboard.web.setup_rq_connection(app)
 ```


## Type of change

Please delete options that are not relevant.

- [ ] Documentation Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works