### PR TITLE
Do not continue to autoreload the job page if a reload fails.

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/scripts/job.js
+++ b/rq_dashboard/templates/rq_dashboard/scripts/job.js
@@ -8,7 +8,7 @@
     var reload_job_info = function(done) {
         api.getJob({{ id|tojson|safe }}, function(job, err) {
             if (err) {
-                return done();
+                return;
             }
             onJobLoaded(job, done);
         });


### PR DESCRIPTION
# Description

Autoreload causes the job page to hit the backend every couple of seconds. However, most RQ implementations set a TTL on jobs in redis. So, this polling will eventually fail. If it continues, it will do so continuously. This makes it difficult for users to set up monitoring and alerting, since these errors eventually overwhelm everything else coming from RQ dashboard. And, the refreshes are meaningless anyway.

This PR stops polling on the job page if a reload fails.

## Type of change

Please delete options that are not relevant.

- [ ] Documentation Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works