### PR TITLE
Fix wording on job page

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/job.html
+++ b/rq_dashboard/templates/rq_dashboard/job.html
@@ -47,7 +47,7 @@
             <p><strong>Ended at</strong>:<br> <%= d.ended_at %></p>
         </span>
         <span class = "row col-12">
-            <p><strong>Execution Info</strong>:</p>
+            <p><strong>Exception Info</strong>:</p>
             <pre class="exc_info col-12"><%= d.exc_info %></pre>
         </span>
 


### PR DESCRIPTION
# Description

First of all, thanks for maintaining this project, it’s a handy tool to have.

I noticed that on the job page, the heading “Execution Info” is used where it should say “Exception Info”. According to the RQ documentation, the `exc_info` key contains exception information: https://github.com/rq/rq/blob/master/docs/contrib/index.md

This PR fixes that wording to better reflect the meaning of the data shown.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works