### PR TITLE
feature: add started_at

### DIFF
--- a/rq_dashboard/templates/rq_dashboard/job.html
+++ b/rq_dashboard/templates/rq_dashboard/job.html
@@ -44,6 +44,7 @@
         <span class="col-6">
             <p><strong>Created at</strong>:<br> <%= d.created_at %></p>
             <p><strong>Enqueued at</strong>:<br> <%= d.enqueued_at %></p>
+            <p><strong>Started at</strong>:<br> <%= d.started_at %></p>
             <p><strong>Ended at</strong>:<br> <%= d.ended_at %></p>
         </span>
         <span class = "row col-12">

--- a/rq_dashboard/templates/rq_dashboard/scripts/job.js
+++ b/rq_dashboard/templates/rq_dashboard/scripts/job.js
@@ -25,6 +25,11 @@
         } else {
             job.enqueued_at = '-'
         }
+        if (job.started_at !== null) {
+            job.started_at = toRelative(Date.create(job.started_at)) + ' / ' + toShort(Date.create(job.started_at));
+        } else {
+            job.started_at = '-'
+        }
         if (job.ended_at !== null) {
             job.ended_at = toRelative(Date.create(job.ended_at)) + ' / ' + toShort(Date.create(job.ended_at));
         } else {

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -209,6 +209,7 @@ def serialize_job(job: Job):
     return dict(
         id=job.id,
         created_at=serialize_date(job.created_at),
+        started_at=serialize_date(job.started_at),
         ended_at=serialize_date(job.ended_at),
         exc_info=latest_result.exc_string if latest_result else None,
         description=job.description,
@@ -606,6 +607,7 @@ def job_info(instance_number, job_id):
         id=job.id,
         created_at=serialize_date(job.created_at),
         enqueued_at=serialize_date(job.enqueued_at),
+        started_at=serialize_date(job.started_at),
         ended_at=serialize_date(job.ended_at),
         origin=job.origin,
         status=job.get_status(),


### PR DESCRIPTION
# Description

This change adds a `Started_at` field before the existing `Ended_at` field, making it easier to understand the job’s execution duration at a glance.


## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
