### PR TITLE
Expose add_basic_auth for embedders

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,13 @@ import rq_dashboard
 app = Flask(__name__)
 app.config.from_object(rq_dashboard.default_settings)
 rq_dashboard.web.setup_rq_connection(app)
+# Optional: require HTTP Basic Auth for the dashboard (e.g. from app config or env)
+if app.config.get("RQ_DASHBOARD_USERNAME"):
+    rq_dashboard.add_basic_auth(
+        rq_dashboard.blueprint,
+        app.config["RQ_DASHBOARD_USERNAME"],
+        app.config["RQ_DASHBOARD_PASSWORD"],
+    )
 app.register_blueprint(rq_dashboard.blueprint, url_prefix="/rq")
 
 @app.route("/")

--- a/rq_dashboard/__init__.py
+++ b/rq_dashboard/__init__.py
@@ -1,3 +1,6 @@
 # flake8: noqa
 from . import default_settings
 from .web import blueprint
+from .cli import add_basic_auth
+
+__all__ = ["blueprint", "default_settings", "add_basic_auth"]


### PR DESCRIPTION
# Description

- Export add_basic_auth from rq_dashboard package (from cli)
- README: integration example shows optional Basic Auth when embedding using RQ_DASHBOARD_USERNAME / RQ_DASHBOARD_PASSWORD

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works