### PR TITLE
Skip corrupt jobs in list and include corrupt_jobs_count in response

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ If you start the Flask app on the default port, you can access the
 dashboard at <http://localhost:5000/rq>. The `cli.py:main` entry point
 provides a simple working example.
 
+The jobs list endpoint skips corrupt or missing jobs and includes
+``corrupt_jobs_count`` in the JSON response.
+
 Running on Heroku
 -----------------
 

--- a/README.md
+++ b/README.md
@@ -113,9 +113,6 @@ If you start the Flask app on the default port, you can access the
 dashboard at <http://localhost:5000/rq>. The `cli.py:main` entry point
 provides a simple working example.
 
-The jobs list endpoint skips corrupt or missing jobs and includes
-``corrupt_jobs_count`` in the JSON response.
-
 Running on Heroku
 -----------------
 

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -40,7 +40,7 @@ from rq import (
     Worker,
     requeue_job,
 )
-from rq.exceptions import NoSuchJobError
+from rq.exceptions import DeserializationError, NoSuchJobError
 from rq.job import Job
 from rq.registry import (
     DeferredJobRegistry,
@@ -271,10 +271,11 @@ def get_queue_registry_jobs_count(queue_name, registry_name, offset, per_page, o
             current_queue = ScheduledJobRegistry(queue_name, connection=connection)
         elif registry_name == "canceled":
             current_queue = CanceledJobRegistry(queue_name, connection=connection)
+        else:
+            current_queue = queue
     else:
         current_queue = queue
     total_items = current_queue.count
-
 
     if order == 'dsc':
         end = total_items - offset
@@ -287,10 +288,18 @@ def get_queue_registry_jobs_count(queue_name, registry_name, offset, per_page, o
     if order == 'dsc':
         job_ids.reverse()
 
-    current_queue_jobs = [queue.fetch_job(job_id) for job_id in job_ids]
-    jobs = [serialize_job(job) for job in current_queue_jobs if job]
+    corrupt_count = 0
+    current_queue_jobs = []
+    for job_id in job_ids:
+        try:
+            job = queue.fetch_job(job_id)
+            if job:
+                current_queue_jobs.append(job)
+        except (NoSuchJobError, DeserializationError):
+            corrupt_count += 1
+    jobs = [serialize_job(job) for job in current_queue_jobs]
 
-    return (total_items, jobs)
+    return (total_items, jobs, corrupt_count)
 
 
 def escape_format_instance_list(url_list):
@@ -508,7 +517,7 @@ def list_jobs(instance_number, queue_name, registry_name, per_page, order, page)
     per_page = int(per_page)
     offset = (current_page - 1) * per_page
 
-    total_items, jobs = get_queue_registry_jobs_count(
+    total_items, jobs, corrupt_count = get_queue_registry_jobs_count(
         queue_name, registry_name, offset, per_page, order, current_app.redis_conn
     )
 
@@ -594,7 +603,11 @@ def list_jobs(instance_number, queue_name, registry_name, per_page, order, page)
     )
 
     return dict(
-        name=queue_name, registry_name=registry_name, jobs=jobs, pagination=pagination
+        name=queue_name,
+        registry_name=registry_name,
+        jobs=jobs,
+        pagination=pagination,
+        corrupt_jobs_count=corrupt_count,
     )
 
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 import json
 import time
 import unittest
+from unittest.mock import patch
 
 import redis
 from rq import Queue, Worker
@@ -87,6 +88,27 @@ class BasicTestCase(unittest.TestCase):
             data = json.loads(response.data.decode('utf8'))
             self.assertIsInstance(data, dict)
             self.assertIn('jobs', data)
+
+    def test_list_jobs_includes_corrupt_jobs_count(self):
+        """List jobs response includes corrupt_jobs_count (skipped missing/corrupt jobs)."""
+        response = self.client.get('/0/data/jobs/default/queued/8/asc/1.json')
+        self.assertEqual(response.status_code, HTTP_OK)
+        data = json.loads(response.data.decode('utf8'))
+        self.assertIn('corrupt_jobs_count', data)
+        self.assertIsInstance(data['corrupt_jobs_count'], int)
+        self.assertGreaterEqual(data['corrupt_jobs_count'], 0)
+
+    def test_list_jobs_corrupt_jobs_count_value(self):
+        """When get_queue_registry_jobs_count reports skipped jobs, response exposes the count."""
+        with patch(
+            'rq_dashboard.web.get_queue_registry_jobs_count',
+            return_value=(10, [], 3),
+        ):
+            response = self.client.get('/0/data/jobs/default/queued/8/asc/1.json')
+        self.assertEqual(response.status_code, HTTP_OK)
+        data = json.loads(response.data.decode('utf8'))
+        self.assertEqual(data['corrupt_jobs_count'], 3)
+        self.assertEqual(data['jobs'], [])
 
     def test_worker_python_version_field(self):
         w = Worker(['q'], connection=self.app.redis_conn)


### PR DESCRIPTION
# Description

When listing jobs (e.g. /data/jobs/<queue>/<registry>/...), a single missing or corrupt job (e.g. NoSuchJobError or DeserializationError from queue.fetch_job()) can make the whole list request fail with a 500. That makes the jobs UI brittle when Redis has stale or corrupted job IDs in a registry.

This change fixes with two improvements:
1. get_queue_registry_jobs_count
Fetches each job in a loop and catches NoSuchJobError and DeserializationError. Corrupt/missing jobs are skipped and counted. The function still returns total registry size and the list of successfully fetched jobs, and now also returns a third value: the number of skipped (corrupt) jobs.

2. list_jobs Uses the new 3-tuple and includes corrupt_jobs_count in the JSON response so the UI or API consumers can show how many jobs were skipped.

## Type of change

- [ ] New feature (non-breaking change which adds functionality)

### Checklist:

- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have run tests (pytest) that prove my fix is effective or that my feature works
- [ ] I have updated the CHANGELOG.md file accordingly
- [ ] I have added tests that prove my fix is effective or that my feature works