### PR TITLE
Add optional toggle to display non-truncated job descriptions

### DIFF
--- a/rq_dashboard/app.py
+++ b/rq_dashboard/app.py
@@ -55,6 +55,10 @@ def _apply_environment_config(app, url_prefix: str) -> None:
         except ValueError:
             pass
 
+    show_full_args_env = os.environ.get("RQ_DASHBOARD_SHOW_FULL_ARGS")
+    if show_full_args_env is not None:
+        app.config["RQ_DASHBOARD_SHOW_FULL_ARGS"] = _str_to_bool(show_full_args_env)
+
     if _str_to_bool(os.environ.get("RQ_DASHBOARD_JSON_SERIALIZER", "false")):
         service_config.serializer = JSONSerializer
 
@@ -71,6 +75,7 @@ def _apply_environment_config(app, url_prefix: str) -> None:
                 "RQ_DASHBOARD_USERNAME",
                 "RQ_DASHBOARD_PASSWORD",
                 "RQ_DASHBOARD_CONFIG",
+                "RQ_DASHBOARD_SHOW_FULL_ARGS",
             }:
                 continue
             app.config[key] = value

--- a/rq_dashboard/cli.py
+++ b/rq_dashboard/cli.py
@@ -162,6 +162,12 @@ def make_flask_app(config, username, password, url_prefix, compatibility_mode=Tr
 @click.option(
     "-j", "--json", is_flag=True, default=False, help="Enable JSONSerializer"
 )
+@click.option(
+    "--show-full-args",
+    is_flag=True, 
+    default=False,
+    help="Display full length of job arguments",
+)
 def run(
     bind,
     port,
@@ -184,6 +190,7 @@ def run(
     disable_delete,
     verbose,
     json,
+    show_full_args,
 ):
     """Run the RQ Dashboard Flask server.
 
@@ -225,6 +232,8 @@ def run(
         app.config["DEPRECATED_OPTIONS"].append("--delete-jobs")
     if poll_interval:
         app.config["RQ_DASHBOARD_POLL_INTERVAL"] = poll_interval
+    if show_full_args:
+        app.config["RQ_DASHBOARD_SHOW_FULL_ARGS"] = show_full_args
     # Conditionally disable Flask console messages
     # See: https://stackoverflow.com/questions/14888799
     log = logging.getLogger("werkzeug")

--- a/rq_dashboard/static/css/main.css
+++ b/rq_dashboard/static/css/main.css
@@ -196,3 +196,15 @@ p.alert-danger {
 #rq-instances:disabled {
     color: black;
 }
+
+.description-scroll {
+    max-height: 200px;          
+    overflow-y: auto;           
+    overflow-wrap: break-word; 
+    background: white;    
+    border: none;              
+    padding: 0;                
+    font-family: 'Helvetica Neue', helvetica, sans-serif;       
+    font-size: inherit;        
+    color: #212529;               
+}

--- a/rq_dashboard/templates/rq_dashboard/job.html
+++ b/rq_dashboard/templates/rq_dashboard/job.html
@@ -19,7 +19,9 @@
 
     <script name="job-info" type="text/template">
         <span class="col-6">
-            <p class="ellipsify"><strong>Description</strong>:<br><%= d.description %></p>
+            <p><strong>Description</strong>:<br>
+                <div class="description-scroll"><%= d.description %></div>
+            </p>
             <p><strong>Origin queue</strong>:<br><%= d.origin %></p>
             <p><strong>Status</strong>:<br><%= d.status %></p>
             <p><strong>Result</strong>:<br><pre><%= JSON.stringify(d.result, null, 2) %></pre></p>

--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -41,6 +41,7 @@ from rq import (
     requeue_job,
 )
 from rq.exceptions import NoSuchJobError
+from rq.utils import get_call_string
 from rq.job import Job
 from rq.registry import (
     BaseRegistry,
@@ -204,6 +205,15 @@ def serialize_date(dt):
     return arrow.get(dt).to("UTC").datetime.isoformat()
 
 
+def format_job_description(job):
+    show_full = current_app.config.get("RQ_DASHBOARD_SHOW_FULL_ARGS", False)
+    
+    if not show_full:
+        return job.description
+
+    return get_call_string(job.func_name, job.args, job.kwargs, max_length=None)
+
+
 def serialize_job(job: Job):
     latest_result = job.latest_result()
     return dict(
@@ -212,7 +222,7 @@ def serialize_job(job: Job):
         started_at=serialize_date(job.started_at),
         ended_at=serialize_date(job.ended_at),
         exc_info=latest_result.exc_string if latest_result else None,
-        description=job.description,
+        description=format_job_description(job),
     )
 
 
@@ -221,7 +231,7 @@ def serialize_current_job(job):
         return "idle"
     return dict(
         job_id=job.id,
-        description=job.description,
+        description=format_job_description(job),
         created_at=serialize_date(job.created_at),
         call_string=job.get_call_string(),
     )
@@ -621,7 +631,7 @@ def job_info(instance_number, job_id):
         status=job.get_status(),
         result=job.return_value(),
         exc_info=latest_result.exc_string if latest_result else None,
-        description=job.description,
+        description=format_job_description(job),
         metadata=json.dumps(job.get_meta(), cls=json_encoder)
     )
     dep_ids = [di.decode("utf-8").split(':')[-1].strip() for di in job.dependency_ids]


### PR DESCRIPTION
# Description

This PR introduces an optional configuration toggle `RQ_DASHBOARD_SHOW_FULL_ARGS` (available via the `--show-full-args` CLI option or environment variable).

By default, the "Description" column is truncated to a fixed length. However, for debugging purposes, users often need to see the complete arguments passed to a function. This change allows full descriptions to be displayed on demand.

The implementation uses `rq.utils.get_call_string` with `max_length=None` to retrieve the full string.

## Backwards compatibility

This change is fully backwards compatible because truncation remains the default behavior.

## Screenshots

## Before:

<img width="1058" height="601" alt="before" src="https://github.com/user-attachments/assets/e5819276-e139-4de0-8b2b-3910046aff03" />

## After:

Setting enabled:

<img width="1058" height="758" alt="enabled" src="https://github.com/user-attachments/assets/72c9c9b0-8c7c-43a4-aaac-5f0ef5519358" />

<br>

Setting disabled:

<img width="1058" height="694" alt="disabled" src="https://github.com/user-attachments/assets/5aa351f4-22d5-48e9-97af-e5c935d23e4a" />

## Type of change

- [x] New feature (non-breaking change which adds functionality)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings