### PR TITLE
Fix AttributeError when viewing job with dependencies

### DIFF
--- a/rq_dashboard/web.py
+++ b/rq_dashboard/web.py
@@ -634,7 +634,10 @@ def job_info(instance_number, job_id):
         description=format_job_description(job),
         metadata=json.dumps(job.get_meta(), cls=json_encoder)
     )
-    dep_ids = [di.decode("utf-8").split(':')[-1].strip() for di in job.dependency_ids]
+    dep_ids = [
+        (di.decode("utf-8") if isinstance(di, bytes) else di).split(':')[-1].strip()
+        for di in job.dependency_ids
+    ]
     if len(dep_ids) > 0:
         result["depends_on"] = dep_ids
         status = []

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,7 @@
 import json
 import time
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, PropertyMock
 
 import redis
 from rq import Queue, Worker
@@ -153,6 +153,32 @@ class BasicTestCase(unittest.TestCase):
         job_info_url = f'/0/data/job/{job.id}.json'
         response_info = self.client.get(job_info_url)
         self.assertEqual(response_info.status_code, HTTP_OK)
+
+    def test_job_info_with_dependency(self):
+        def some_work():
+            return
+        q = Queue(connection=self.app.redis_conn)
+        job1 = q.enqueue(some_work)
+        job2 = q.enqueue(some_work, depends_on=job1)
+        job_info_url = f'/0/data/job/{job2.id}.json'
+        response_info = self.client.get(job_info_url)
+        self.assertEqual(response_info.status_code, HTTP_OK)
+
+    def test_job_info_with_dependency_str(self):
+        """Simulate rq >= 2.6, where dependency_ids returns str, not bytes."""
+        def some_work():
+            return
+        q = Queue(connection=self.app.redis_conn)
+        job1 = q.enqueue(some_work)
+        job2 = q.enqueue(some_work, depends_on=job1)
+        with patch(
+                'rq.job.Job.dependency_ids',
+                new_callable=PropertyMock,
+                return_value=[f'{job1.id}'],
+        ):
+            job_info_url = f'/0/data/job/{job2.id}.json'
+            response_info = self.client.get(job_info_url)
+            self.assertEqual(response_info.status_code, HTTP_OK)
 
     def test_compact_queue(self):
         def some_work():


### PR DESCRIPTION
# Description

Viewing a job that has a dependency renders a blank page:

<img width="2868" height="1558" alt="HTTP 500 error on RQ Dashboard jobs page" src="https://github.com/user-attachments/assets/e841c5f9-d087-49b4-8d1e-a56656187547" />

The RQ Dashboard logs show why:

```bash
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
[2026-07-07 11:16:43,467] ERROR in app: Exception on /0/data/job/98a68b1d-37bb-46f1-9738-57b79315abdf.json [GET]
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/usr/local/lib/python3.13/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/rq_dashboard/web.py", line 110, in _wrapped
    result_dict = f(*args, **kwargs)
  File "/usr/local/lib/python3.13/site-packages/rq_dashboard/web.py", line 637, in job_info
    dep_ids = [di.decode("utf-8").split(':')[-1].strip() for di in job.dependency_ids]
               ^^^^^^^^^
AttributeError: 'str' object has no attribute 'decode'. Did you mean: 'encode'?
```

---

RQ changed `job.dependency_ids` to return a list of strings instead of bytes via [this commit](https://github.com/rq/rq/commit/41928f025179c5bb59b108ecef643394f5c9d793#diff-5ff734c15373fbcdb39d32faf0555265d8eaae657c1a6174e5e9b0dedd2815f7). This took effect in RQ version `2.6.0`. Hence, the `.decode("utf-8")` call in `web.py` is now redundant for this version and beyond.

Since `rq-dashboard` supports `rq>=1.0` with no upper bound, it is assumed that the fix needs to handle both bytes (pre-2.6.0) and str (2.6.0+). I'm not sure if there's a better way to handle this and I am happy to modify the approach:

```python
dep_ids = [
    (di.decode("utf-8") if isinstance(di, bytes) else di).split(':')[-1].strip()
    for di in job.dependency_ids
]
```

I reproduced this using this test repo: https://github.com/matt-andersen/rq-test-stack. It has two workers, two queues, and one job set to depend on the other. I confirmed the job page loads with an error on the current RQ Dashboard version, and loads fine with the fix applied. I also wrote a unit test (`test_job_info_with_dependency_str`) that mocks the string return values to simulate RQ >= 2.6.0, since the test environment runs RQ 2.0.0.

---

Fixes #522 

## Type of change

Please delete options that are not relevant.
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist:

- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have run tests (pytest) that prove my fix is effective or that my feature works
- [x] I have added tests that prove my fix is effective or that my feature works